### PR TITLE
NullPointer crash in TileExternalStorage (worldObj is null on world load)

### DIFF
--- a/src/main/java/refinedstorage/tile/TileExternalStorage.java
+++ b/src/main/java/refinedstorage/tile/TileExternalStorage.java
@@ -163,6 +163,7 @@ public class TileExternalStorage extends TileMachine implements IStorageProvider
     }
 
     public TileEntity getConnectedTile() {
+        if(worldObj == null) return null;
         TileEntity tile = worldObj.getTileEntity(pos.offset(getDirection()));
 
         if (tile instanceof IInventory || tile instanceof IDeepStorageUnit) {

--- a/src/main/java/refinedstorage/tile/TileExternalStorage.java
+++ b/src/main/java/refinedstorage/tile/TileExternalStorage.java
@@ -34,8 +34,7 @@ public class TileExternalStorage extends TileMachine implements IStorageProvider
     private int compare = 0;
     private int mode = 0;
 
-    @SideOnly(Side.CLIENT)
-    private int stored = 0;
+   private int stored = 0;
 
     @Override
     public int getEnergyUsage() {


### PR DESCRIPTION
[06:55:08] [Server thread/ERROR]: Encountered an unexpected exception
net.minecraft.util.ReportedException: Ticking block entity
    at net.minecraft.server.MinecraftServer.updateTimeLightAndEntities(MinecraftServer.java:785) ~[MinecraftServer.class:?]
    at net.minecraft.server.dedicated.DedicatedServer.updateTimeLightAndEntities(DedicatedServer.java:407) ~[DedicatedServer.class:?]
    at net.minecraft.server.MinecraftServer.tick(MinecraftServer.java:683) ~[MinecraftServer.class:?]
    at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:532) [MinecraftServer.class:?]
    at java.lang.Thread.run(Unknown Source) [?:1.8.0_71]
Caused by: java.lang.NoSuchFieldError: stored
    at refinedstorage.tile.TileExternalStorage.<init>(TileExternalStorage.java:37) ~[TileExternalStorage.class:?]
    at refinedstorage.block.BlockExternalStorage.createTileEntity(BlockExternalStorage.java:22) ~[BlockExternalStorage.class:?]
    at net.minecraft.world.chunk.Chunk.createNewTileEntity(Chunk.java:811) ~[Chunk.class:?]
    at net.minecraft.world.chunk.Chunk.getTileEntity(Chunk.java:828) ~[Chunk.class:?]
    at net.minecraft.world.World.getTileEntity(World.java:2571) ~[World.class:?]
    at refinedstorage.tile.MachineSearcher.search(MachineSearcher.java:22) ~[MachineSearcher.class:?]
    at refinedstorage.tile.MachineSearcher.search(MachineSearcher.java:43) ~[MachineSearcher.class:?]
    at refinedstorage.tile.MachineSearcher.search(MachineSearcher.java:43) ~[MachineSearcher.class:?]
    at refinedstorage.tile.MachineSearcher.search(MachineSearcher.java:43) ~[MachineSearcher.class:?]
    at refinedstorage.tile.MachineSearcher.search(MachineSearcher.java:43) ~[MachineSearcher.class:?]
    at refinedstorage.tile.TileController.update(TileController.java:61) ~[TileController.class:?]
    at net.minecraft.world.World.updateEntities(World.java:1936) ~[World.class:?]
    at net.minecraft.world.WorldServer.updateEntities(WorldServer.java:637) ~[WorldServer.class:?]
    at net.minecraft.server.MinecraftServer.updateTimeLightAndEntities(MinecraftServer.java:779) ~[MinecraftServer.class:?]
    ... 4 more
