### PR TITLE
Fixes index out of bounds and prevent list from being modified by other threads on the client while rendering

### DIFF
--- a/src/main/java/refinedstorage/gui/GuiGrid.java
+++ b/src/main/java/refinedstorage/gui/GuiGrid.java
@@ -133,7 +133,9 @@ public class GuiGrid extends GuiBase {
 
         for (int i = 0; i < 9 * getVisibleRows(); ++i) {
             if (slot < items.size()) {
-                int qty = items.get(slot).getQuantity();
+                StorageItem storageItem = items.get(slot);
+            	if(storageItem == null) continue;
+            	int qty = storageItem.getQuantity();
 
                 String text;
 

--- a/src/main/java/refinedstorage/gui/GuiGrid.java
+++ b/src/main/java/refinedstorage/gui/GuiGrid.java
@@ -111,7 +111,7 @@ public class GuiGrid extends GuiBase {
     @Override
     public void drawForeground(int mouseX, int mouseY) {
         scrollbar.update(this, mouseX, mouseY);
-
+    synchronized (grid.getController()) {    
         drawString(7, 7, t("gui.refinedstorage:grid"));
 
         if (grid.getType() == EnumGridType.CRAFTING) {
@@ -133,9 +133,7 @@ public class GuiGrid extends GuiBase {
 
         for (int i = 0; i < 9 * getVisibleRows(); ++i) {
             if (slot < items.size()) {
-                StorageItem storageItem = items.get(slot);
-            	if(storageItem == null) continue;
-            	int qty = storageItem.getQuantity();
+            	int qty = items.get(slot).getQuantity();
 
                 String text;
 
@@ -191,6 +189,7 @@ public class GuiGrid extends GuiBase {
         if (isHoveringOverClear(mouseX, mouseY)) {
             drawTooltip(mouseX, mouseY, t("misc.refinedstorage:clear"));
         }
+    }
     }
 
     public List<StorageItem> getItems() {


### PR DESCRIPTION
Think instead of all these null checks, maybe not set that list from the network packet as that is another thread, and instead set a temporary list that the gui forground then pull into the main list before rendering.
