### PR TITLE
Correct RF usage, Use energy every tick not every sec

### DIFF
--- a/src/main/java/refinedstorage/tile/TileController.java
+++ b/src/main/java/refinedstorage/tile/TileController.java
@@ -49,6 +49,15 @@ public class TileController extends TileBase implements IEnergyReceiver, INetwor
         if (!worldObj.isRemote) {
             int lastEnergy = energy.getEnergyStored();
 
+                switch (getType()) {
+                    case NORMAL:
+                        energy.extractEnergy(energyUsage, false);
+                        break;
+                    case CREATIVE:
+                        energy.setEnergyStored(energy.getMaxEnergyStored());
+                        break;
+                }
+
             if (ticks % 20 == 0) {
                 if (!isActive()) {
                     disconnectAll();
@@ -97,15 +106,6 @@ public class TileController extends TileBase implements IEnergyReceiver, INetwor
                     for (TileMachine machine : machines) {
                         energyUsage += machine.getEnergyUsage();
                     }
-                }
-
-                switch (getType()) {
-                    case NORMAL:
-                        energy.extractEnergy(energyUsage, false);
-                        break;
-                    case CREATIVE:
-                        energy.setEnergyStored(energy.getMaxEnergyStored());
-                        break;
                 }
 
                 if (lastEnergy != energy.getEnergyStored()) {

--- a/src/main/java/refinedstorage/tile/TileController.java
+++ b/src/main/java/refinedstorage/tile/TileController.java
@@ -49,6 +49,7 @@ public class TileController extends TileBase implements IEnergyReceiver, INetwor
         if (!worldObj.isRemote) {
             int lastEnergy = energy.getEnergyStored();
 
+                if(isActive())
                 switch (getType()) {
                     case NORMAL:
                         energy.extractEnergy(energyUsage, false);


### PR DESCRIPTION
Moved Energy usage outside the ticks % 20 block, amount to draw is updated every sec as before
