### PR TITLE
Fixed grid searching controller over null blocks

### DIFF
--- a/src/main/java/refinedstorage/tile/TileMachine.java
+++ b/src/main/java/refinedstorage/tile/TileMachine.java
@@ -81,7 +81,7 @@ public abstract class TileMachine extends TileBase implements ISynchronizedConta
     }
 
     public void onConnected(World world, TileController controller) {
-        if (tryConnect(controller)) {
+        if (tryConnect(controller) && block != null) {
             world.notifyNeighborsOfStateChange(pos, block);
         }
     }


### PR DESCRIPTION
When placing a cable above a door and triggering a searchController
call from a connected grid (e.g. by loading the chunk), then onConnected
would try to notify neighbors of a state change with block set to null.
This caused a NPE down the line.

To reproduce build this and reload the world:
![2016-06-19_11 33 13](https://cloud.githubusercontent.com/assets/205210/16176597/da29a18e-3612-11e6-9ecc-539291b508e9.png)

Probably the same as #124
