### PR TITLE
Add Crafting Tweaks integration

### DIFF
--- a/src/main/java/refinedstorage/RefinedStorage.java
+++ b/src/main/java/refinedstorage/RefinedStorage.java
@@ -14,6 +14,7 @@ import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
 import net.minecraftforge.fml.common.network.simpleimpl.SimpleNetworkWrapper;
+import refinedstorage.integration.IntegrationCraftingTweaks;
 import refinedstorage.proxy.CommonProxy;
 
 @Mod(modid = RefinedStorage.ID, version = RefinedStorage.VERSION, dependencies = RefinedStorage.DEPENDENCIES)
@@ -149,6 +150,8 @@ public final class RefinedStorage {
         translucentCables = config.getBoolean("translucentCables", "misc", false, "For resource pack makers that want a translucent cable");
 
         config.save();
+
+        IntegrationCraftingTweaks.register();
     }
 
     @EventHandler

--- a/src/main/java/refinedstorage/integration/IntegrationCraftingTweaks.java
+++ b/src/main/java/refinedstorage/integration/IntegrationCraftingTweaks.java
@@ -18,7 +18,7 @@ public class IntegrationCraftingTweaks {
 			tagCompound.setString("ContainerCallback", ContainerCallback.class.getName());
 			tagCompound.setInteger("GridSlotNumber", 36);
 			tagCompound.setString("AlignToGrid", "left");
-			FMLInterModComms.sendMessage(MOD_ID, "RegisterProvider", tagCompound);
+			FMLInterModComms.sendMessage(MOD_ID, "RegisterProviderV2", tagCompound);
 		}
 	}
 

--- a/src/main/java/refinedstorage/integration/IntegrationCraftingTweaks.java
+++ b/src/main/java/refinedstorage/integration/IntegrationCraftingTweaks.java
@@ -1,0 +1,31 @@
+package refinedstorage.integration;
+
+import com.google.common.base.Function;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.event.FMLInterModComms;
+import refinedstorage.block.EnumGridType;
+import refinedstorage.container.ContainerGrid;
+
+public class IntegrationCraftingTweaks {
+
+	public static final String MOD_ID = "craftingtweaks";
+
+	public static void register() {
+		if(Loader.isModLoaded(MOD_ID)) {
+			NBTTagCompound tagCompound = new NBTTagCompound();
+			tagCompound.setString("ContainerClass", ContainerGrid.class.getName());
+			tagCompound.setString("ContainerCallback", ContainerCallback.class.getName());
+			tagCompound.setInteger("GridSlotNumber", 36);
+			tagCompound.setString("AlignToGrid", "left");
+			FMLInterModComms.sendMessage(MOD_ID, "RegisterProvider", tagCompound);
+		}
+	}
+
+	public static class ContainerCallback implements Function<ContainerGrid, Boolean> {
+		@Override
+		public Boolean apply(ContainerGrid containerGrid) {
+			return containerGrid.getGrid().getType() == EnumGridType.CRAFTING;
+		}
+	}
+}


### PR DESCRIPTION
This utilizes [Crafting Tweaks](https://minecraft.curseforge.com/projects/crafting-tweaks)' IMC API to add support for its crafting buttons (rotate/balance/spread/clear) to the "Crafting Grid".

Compatible with Crafting Tweaks v6.1.12 or higher.
