### PR TITLE
Fix ArrayIndexOutOfBoundsException in satisfiedInsertion

### DIFF
--- a/src/main/java/refinedstorage/apiimpl/autocrafting/task/CraftingTaskProcessing.java
+++ b/src/main/java/refinedstorage/apiimpl/autocrafting/task/CraftingTaskProcessing.java
@@ -23,7 +23,7 @@ public class CraftingTaskProcessing extends CraftingTask {
         super(pattern);
 
         this.satisfied = new boolean[pattern.getInputs().size()];
-        this.satisfiedInsertion = new boolean[pattern.getInputs().size()];
+        this.satisfiedInsertion = new boolean[pattern.getOutputs().size()];
         this.checked = new boolean[pattern.getInputs().size()];
     }
 


### PR DESCRIPTION
This should fix a crash that occurs if a crafting pattern produces more outputs than it consumes inputs.
Should also fix a possible deadlock with isDone returning false.
This will NOT fix the crash if the bug has already written wrong-length arrays to NBT data, that would need a separate workaround.
