### PR TITLE
Add method to get the missing items from an ICraftingTask

### DIFF
--- a/src/main/java/refinedstorage/api/autocrafting/task/ICraftingTask.java
+++ b/src/main/java/refinedstorage/api/autocrafting/task/ICraftingTask.java
@@ -1,11 +1,13 @@
 package refinedstorage.api.autocrafting.task;
 
+import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 import refinedstorage.api.autocrafting.ICraftingPattern;
 import refinedstorage.api.network.INetworkMaster;
 
 import javax.annotation.Nullable;
+import java.util.List;
 
 /**
  * Represents a crafting task.
@@ -59,4 +61,9 @@ public interface ICraftingTask {
      * @return The progress for display in the crafting monitor, -1 for no progress
      */
     int getProgress();
+
+    /**
+     * @return The items that are required for this tasks's crafting pattern, but are not present.
+     */
+    List<ItemStack> getMissingItems();
 }

--- a/src/main/java/refinedstorage/apiimpl/autocrafting/task/CraftingTaskNormal.java
+++ b/src/main/java/refinedstorage/apiimpl/autocrafting/task/CraftingTaskNormal.java
@@ -1,11 +1,14 @@
 package refinedstorage.apiimpl.autocrafting.task;
 
+import com.google.common.collect.Lists;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 import refinedstorage.api.autocrafting.ICraftingPattern;
 import refinedstorage.api.network.INetworkMaster;
 import refinedstorage.api.network.NetworkUtils;
+
+import java.util.List;
 
 public class CraftingTaskNormal extends CraftingTask {
     public static final String NBT_SATISFIED = "Satisfied";
@@ -127,5 +130,17 @@ public class CraftingTaskNormal extends CraftingTask {
         }
 
         return (int) ((float) satisfiedAmount / (float) satisfied.length * 100F);
+    }
+
+    @Override
+    public List<ItemStack> getMissingItems() {
+        List<ItemStack> missingItemStacks = Lists.newArrayList();
+        for (int i = 0; i < pattern.getInputs().size(); ++i) {
+            ItemStack input = pattern.getInputs().get(i);
+            if (!satisfied[i] && childrenCreated[i] && checked[i]) {
+                missingItemStacks.add(input);
+            }
+        }
+        return missingItemStacks;
     }
 }

--- a/src/main/java/refinedstorage/apiimpl/autocrafting/task/CraftingTaskProcessing.java
+++ b/src/main/java/refinedstorage/apiimpl/autocrafting/task/CraftingTaskProcessing.java
@@ -1,5 +1,6 @@
 package refinedstorage.apiimpl.autocrafting.task;
 
+import com.google.common.collect.Lists;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
@@ -9,6 +10,8 @@ import refinedstorage.api.autocrafting.ICraftingPatternContainer;
 import refinedstorage.api.network.INetworkMaster;
 import refinedstorage.api.network.NetworkUtils;
 import refinedstorage.api.storage.CompareUtils;
+
+import java.util.List;
 
 public class CraftingTaskProcessing extends CraftingTask {
     public static final String NBT_SATISFIED = "Satisfied";
@@ -197,5 +200,17 @@ public class CraftingTaskProcessing extends CraftingTask {
         }
 
         return (int) ((float) satisfiedAmount / (float) (satisfied.length + satisfiedInsertion.length) * 100F);
+    }
+
+    @Override
+    public List<ItemStack> getMissingItems() {
+        List<ItemStack> missingItemStacks = Lists.newArrayList();
+        for (int i = 0; i < pattern.getInputs().size(); ++i) {
+            ItemStack input = pattern.getInputs().get(i);
+            if (!satisfied[i] && childrenCreated[i] && checked[i]) {
+                missingItemStacks.add(input);
+            }
+        }
+        return missingItemStacks;
     }
 }


### PR DESCRIPTION
I currently use some very nasty reflection to calculate a task's missing items: https://github.com/CyclopsMC/IntegratedDynamics/commit/ba9360e537ab31bc9889c89bdded9cdbc24f5c57
This PR makes it possible to clean this up.

Other future API users might also benefit from this.

Currently, the implementation for `getMissingItems` has been duplicated for `CraftingTaskNormal` and `CraftingTaskProcessing`.
It would be possible to move the 3 boolean arrays to `CraftingTask`, and move `getMissingItems` there as well for a better abstraction, but I haven't done this here, maybe you had a certain reason to do it like this.
