### PR TITLE
Fixing a common bug on EU Supporters

### DIFF
--- a/src/main/java/com/raoulvdberge/refinedstorage/integration/ic2/ControllerEnergyIC2.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/integration/ic2/ControllerEnergyIC2.java
@@ -8,7 +8,7 @@ public class ControllerEnergyIC2 implements IControllerEnergyIC2 {
     private BasicSink sink;
 
     public ControllerEnergyIC2(final TileController controller) {
-        this.sink = new BasicSink(controller, (int) IntegrationIC2.toEU(controller.getEnergy().getMaxEnergyStored()), Integer.MAX_VALUE) {
+        this.sink = new BasicSink(controller, (int) IntegrationIC2.toEU(controller.getEnergy().getMaxEnergyStored()), 3 /** HV is fair since packet exists */) { //Energy Tiers are only from 0-13 anyhing higer just resets it. Also classic would force you to do tier 1 if you go any higher then 13.
             @Override
             public double getDemandedEnergy() {
                 return Math.max(0.0D, IntegrationIC2.toEU(controller.getEnergy().getMaxEnergyStored()) - IntegrationIC2.toEU(controller.getEnergy().getEnergyStored()));

--- a/src/main/java/com/raoulvdberge/refinedstorage/integration/ic2/ControllerEnergyIC2.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/integration/ic2/ControllerEnergyIC2.java
@@ -8,7 +8,7 @@ public class ControllerEnergyIC2 implements IControllerEnergyIC2 {
     private BasicSink sink;
 
     public ControllerEnergyIC2(final TileController controller) {
-        this.sink = new BasicSink(controller, (int) IntegrationIC2.toEU(controller.getEnergy().getMaxEnergyStored()), 3 /** HV is fair since packet exists */) { //Energy Tiers are only from 0-13 anyhing higer just resets it. Also classic would force you to do tier 1 if you go any higher then 13.
+        this.sink = new BasicSink(controller, (int) IntegrationIC2.toEU(controller.getEnergy().getMaxEnergyStored()), 3) {
             @Override
             public double getDemandedEnergy() {
                 return Math.max(0.0D, IntegrationIC2.toEU(controller.getEnergy().getMaxEnergyStored()) - IntegrationIC2.toEU(controller.getEnergy().getEnergyStored()));


### PR DESCRIPTION
As i told in the doc. IC2 has tiers in EU. The limit is 0-13 if you go any higher or lower then you start to reset.
Basicly Anything higher is overflowing a Integer also causes longer math etc.
HV i think is the perfect voltage for 1 reason: EU Has energy Packets in Both IC2s. That means You can send in 10 Million EU per tick but these are only HV Packets so nothing will explode. So if anyone tries to do this bla bla bla...
Anyway if you think 3 is to low. Go higher but stay in range of 0-13 Classic would reset you to LV if you do that...
