### PR TITLE
OreDict support for the Processing Pattern Encoder.

### DIFF
--- a/src/main/java/com/raoulvdberge/refinedstorage/proxy/ProxyCommon.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/proxy/ProxyCommon.java
@@ -377,16 +377,16 @@ public class ProxyCommon {
         );
 
         // Processing Pattern Encoder
-        GameRegistry.addRecipe(new ItemStack(RSBlocks.PROCESSING_PATTERN_ENCODER),
+        GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(RSBlocks.PROCESSING_PATTERN_ENCODER),
             "ECE",
             "PMP",
             "EFE",
             'E', new ItemStack(RSItems.QUARTZ_ENRICHED_IRON),
             'M', new ItemStack(RSBlocks.MACHINE_CASING),
             'P', new ItemStack(RSItems.PATTERN),
-            'C', new ItemStack(Blocks.CRAFTING_TABLE),
+            'C', "workbench",
             'F', new ItemStack(Blocks.FURNACE)
-        );
+        ));
 
         // External Storage
         GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(RSBlocks.EXTERNAL_STORAGE),


### PR DESCRIPTION
Added the "workbench" tag for the Crafting Table in the Processing Pattern Encoder.  This allows it to use crafting tables from other mods, including the Crafting Station from Tinkers' Construct.  #969 

It appears that the Solderer recipes are looking for ItemStacks and do not like the strings for ore dictionary support.  I'm not sure how to add the ore dictionary versions to the Crafting Grid, Crafting Upgrade, or Disk Drive.