### PR TITLE
OreDictionary Support for the PPE and Security Manager.

### DIFF
--- a/src/main/java/com/raoulvdberge/refinedstorage/proxy/ProxyCommon.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/proxy/ProxyCommon.java
@@ -435,7 +435,7 @@ public class ProxyCommon {
             'E', new ItemStack(RSItems.QUARTZ_ENRICHED_IRON),
             'M', new ItemStack(RSBlocks.MACHINE_CASING),
             'P', new ItemStack(RSItems.PATTERN),
-            'C', new ItemStack(Blocks.CRAFTING_TABLE),
+            'C', "workbench",
             'F', new ItemStack(Blocks.FURNACE)
         );
 
@@ -786,7 +786,7 @@ public class ProxyCommon {
             'P', new ItemStack(RSItems.PROCESSOR, 1, ItemProcessor.TYPE_ADVANCED),
             'M', new ItemStack(RSBlocks.MACHINE_CASING),
             'S', new ItemStack(RSItems.SECURITY_CARD),
-            'C', new ItemStack(Blocks.CHEST)
+            'C', "chest"
         );
 
         // Security Card

--- a/src/main/java/com/raoulvdberge/refinedstorage/proxy/ProxyCommon.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/proxy/ProxyCommon.java
@@ -428,7 +428,7 @@ public class ProxyCommon {
         );
 
         // Processing Pattern Encoder
-        GameRegistry.addRecipe(new ItemStack(RSBlocks.PROCESSING_PATTERN_ENCODER),
+        GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(RSBlocks.PROCESSING_PATTERN_ENCODER),
             "ECE",
             "PMP",
             "EFE",
@@ -437,7 +437,7 @@ public class ProxyCommon {
             'P', new ItemStack(RSItems.PATTERN),
             'C', "workbench",
             'F', new ItemStack(Blocks.FURNACE)
-        );
+        ));
 
         // External Storage
         GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(RSBlocks.EXTERNAL_STORAGE),
@@ -778,7 +778,7 @@ public class ProxyCommon {
         );
 
         // Security Manager
-        GameRegistry.addShapedRecipe(new ItemStack(RSBlocks.SECURITY_MANAGER),
+        GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(RSBlocks.SECURITY_MANAGER),
             "ECE",
             "SMS",
             "ESE",
@@ -787,7 +787,7 @@ public class ProxyCommon {
             'M', new ItemStack(RSBlocks.MACHINE_CASING),
             'S', new ItemStack(RSItems.SECURITY_CARD),
             'C', "chest"
-        );
+        ));
 
         // Security Card
         GameRegistry.addShapedRecipe(new ItemStack(RSItems.SECURITY_CARD),


### PR DESCRIPTION
Added the "workbench" tag for the Crafting Table in the Processing Pattern Encoder, and the "chest" tag for the Security Manager. This allows them to use crafting tables and chests from other mods, including the Crafting Station from Tinkers' Construct and the Chests from Quark. #969

It appears that the Solderer recipes are looking for ItemStacks and do not like the strings for ore dictionary support. I'm not sure how to add the ore dictionary versions to the Crafting Grid, Crafting Upgrade, or Disk Drive.