### PR TITLE
Fix Crafting Pattern Models

### DIFF
--- a/src/main/java/com/raoulvdberge/refinedstorage/proxy/ProxyClient.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/proxy/ProxyClient.java
@@ -268,14 +268,15 @@ public class ProxyClient extends ProxyCommon {
         super.init(e);
 
         // Register IItemColor to handle passthrough
-        Minecraft.getMinecraft().getItemColors().registerItemColorHandler(new IItemColor() {
+        ItemColors mcColors = Minecraft.getMinecraft().getItemColors();
+        mcColors.registerItemColorHandler(new IItemColor() {
             @Override
             public int getColorFromItemstack(ItemStack stack, int tintIndex) {
                 CraftingPattern pattern = ItemPattern.getPatternFromCache(Minecraft.getMinecraft().world, stack);
 
-                if (GuiBase.isShiftKeyDown() && pattern.isValid() && pattern.getOutputs().size() == 1 &&
-                        Minecraft.getMinecraft().getItemColors().getColorFromItemstack(pattern.getOutputs().get(0), tintIndex) != -1) {
-                    return Minecraft.getMinecraft().getItemColors().getColorFromItemstack(pattern.getOutputs().get(0), tintIndex); // Take the item
+                if (BakedModelPattern.displayPatternOutput(pattern) &&
+                        mcColors.getColorFromItemstack(pattern.getOutputs().get(0), tintIndex) != -1) {
+                    return mcColors.getColorFromItemstack(pattern.getOutputs().get(0), tintIndex); // Take the item
                 }
 
                 return 0xFFFFFF; // Full white, no need to apply color

--- a/src/main/java/com/raoulvdberge/refinedstorage/render/BakedModelPattern.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/render/BakedModelPattern.java
@@ -1,5 +1,6 @@
 package com.raoulvdberge.refinedstorage.render;
 
+import com.google.common.collect.ImmutableMap;
 import com.raoulvdberge.refinedstorage.apiimpl.autocrafting.CraftingPattern;
 import com.raoulvdberge.refinedstorage.gui.GuiBase;
 import com.raoulvdberge.refinedstorage.item.ItemPattern;
@@ -14,12 +15,33 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.world.World;
+import net.minecraftforge.client.model.IPerspectiveAwareModel;
+import net.minecraftforge.common.model.TRSRTransformation;
+import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nullable;
+import javax.vecmath.Matrix4f;
 import java.util.List;
 
-public class BakedModelPattern implements IBakedModel {
+public class BakedModelPattern implements IBakedModel, IPerspectiveAwareModel {
     private IBakedModel patternModel;
+
+    private static TRSRTransformation get(float tx, float ty, float tz, float ax, float ay, float az, float s) {
+        return new TRSRTransformation(
+                new javax.vecmath.Vector3f(tx / 16, ty / 16, tz / 16),
+                TRSRTransformation.quatFromXYZDegrees(new javax.vecmath.Vector3f(ax, ay, az)),
+                new javax.vecmath.Vector3f(s, s, s),
+                null);
+    }
+
+    private static ImmutableMap<ItemCameraTransforms.TransformType, TRSRTransformation> transforms =
+            ImmutableMap.<ItemCameraTransforms.TransformType, TRSRTransformation>builder()
+                    .put(ItemCameraTransforms.TransformType.THIRD_PERSON_RIGHT_HAND,     get(0, 3, 1, 0, 0, 0, 0.55f))
+                    .put(ItemCameraTransforms.TransformType.THIRD_PERSON_LEFT_HAND,      get(0, 3, 1, 0, 0, 0, 0.55f))
+                    .put(ItemCameraTransforms.TransformType.FIRST_PERSON_RIGHT_HAND,     get(1.13f, 3.2f, 1.13f, 0, -90, 25, 0.68f))
+                    .put(ItemCameraTransforms.TransformType.FIRST_PERSON_LEFT_HAND,      get(1.13f, 3.2f, 1.13f, 0, 90, -25, 0.68f))
+                    .put(ItemCameraTransforms.TransformType.GROUND,                      get(0, 2, 0, 0, 0, 0, 0.5f))
+                    .put(ItemCameraTransforms.TransformType.HEAD,                        get(0, 13, 7, 0, 180, 0, 1)).build();
 
     public BakedModelPattern(IBakedModel patternModel) {
         this.patternModel = patternModel;
@@ -70,5 +92,12 @@ public class BakedModelPattern implements IBakedModel {
                 return super.handleItemState(originalModel, stack, world, entity);
             }
         };
+    }
+
+    @Override
+    public Pair<? extends IBakedModel, Matrix4f> handlePerspective(ItemCameraTransforms.TransformType cameraTransformType) {
+        return Pair.of(this,
+                transforms.get(cameraTransformType) != null ?
+                        transforms.get(cameraTransformType).getMatrix() : get(0, 0, 0, 0, 0, 0, 1.0f).getMatrix());
     }
 }

--- a/src/main/java/com/raoulvdberge/refinedstorage/render/BakedModelPattern.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/render/BakedModelPattern.java
@@ -85,7 +85,7 @@ public class BakedModelPattern implements IBakedModel, IPerspectiveAwareModel {
             public IBakedModel handleItemState(IBakedModel originalModel, ItemStack stack, World world, EntityLivingBase entity) {
                 CraftingPattern pattern = ItemPattern.getPatternFromCache(world, stack);
 
-                if (GuiBase.isShiftKeyDown() && pattern.isValid() && pattern.getOutputs().size() == 1) {
+                if (displayPatternOutput(pattern)) {
                     return Minecraft.getMinecraft().getRenderItem().getItemModelWithOverrides(pattern.getOutputs().get(0), world, entity);
                 }
 
@@ -99,5 +99,14 @@ public class BakedModelPattern implements IBakedModel, IPerspectiveAwareModel {
         return Pair.of(this,
                 transforms.get(cameraTransformType) != null ?
                         transforms.get(cameraTransformType).getMatrix() : get(0, 0, 0, 0, 0, 0, 1.0f).getMatrix());
+    }
+
+    /**
+     * Determines if the pattern output should be displayed
+     * @param pattern The pattern to check
+     * @return True to render output, not pattern item
+     */
+    public static boolean displayPatternOutput(CraftingPattern pattern) {
+        return GuiBase.isShiftKeyDown() && pattern.isValid() && pattern.getOutputs().size() == 1;
     }
 }


### PR DESCRIPTION
This will standardize the transforms to look like a normal item and will also apply the IItemColor object from the stored item to the item, allowing things like potions, spawn eggs, and other implementations to show correct color