### PR TITLE
Fix connections conductivity

### DIFF
--- a/src/main/java/com/raoulvdberge/refinedstorage/api/IRSAPI.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/api/IRSAPI.java
@@ -106,4 +106,9 @@ public interface IRSAPI {
      * @return a set with the predicates to check if a block is connectable
      */
     Set<Predicate<TileEntity>> getConnectableConditions();
+
+    /**
+     * @return whether the provided TileEntity matches any of the current connectable conditions
+     */
+    boolean hasConnectableConditions(TileEntity te);
 }

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/API.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/API.java
@@ -142,4 +142,9 @@ public class API implements IRSAPI {
             }
         }
     }
+
+	@Override
+	public boolean hasConnectableConditions(TileEntity te) {
+		return connectableConditions.stream().anyMatch(p -> p.test(te));
+	}
 }

--- a/src/main/java/com/raoulvdberge/refinedstorage/block/BlockCable.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/block/BlockCable.java
@@ -159,20 +159,15 @@ public class BlockCable extends BlockCoverable {
         if (isConnectable) {
             TileEntity tile = world.getTileEntity(pos);
 
-            // The target block isConnectable, can we conduct to them?
-            if (tile instanceof INetworkNode && !((INetworkNode) tile).canConduct(direction)) {
-                return false;
-            }
+            // Special checks for INetworkNodes
+            if (tile instanceof INetworkNode) {
 
-            // Do not render a cable extension where our cable "head" is (e.g. importer, exporter, external storage heads).
-            if (tile instanceof TileMultipartNode) {
-                TileMultipartNode multipartNode = (TileMultipartNode) tile;
-
-                if (getPlacementType() != null && multipartNode != null && multipartNode.getFacingTile() == facing) {
+                // Do not render a cable extension where our cable "head" is (e.g. importer, exporter, external storage heads).
+                if (tile instanceof TileMultipartNode && getPlacementType() != null && ((TileMultipartNode) tile).getFacingTile() == facing) {
                     return false;
                 }
 
-                return !TileMultipartNode.hasBlockingMicroblock(world, pos, direction) && !TileMultipartNode.hasBlockingMicroblock(world, pos.offset(direction), direction.getOpposite());
+                return ((INetworkNode) tile).canConduct(direction);
             }
 
             return true;

--- a/src/main/java/com/raoulvdberge/refinedstorage/block/BlockCable.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/block/BlockCable.java
@@ -2,6 +2,7 @@ package com.raoulvdberge.refinedstorage.block;
 
 import com.raoulvdberge.refinedstorage.RS;
 import com.raoulvdberge.refinedstorage.api.network.INetworkMaster;
+import com.raoulvdberge.refinedstorage.api.network.INetworkNode;
 import com.raoulvdberge.refinedstorage.apiimpl.API;
 import com.raoulvdberge.refinedstorage.tile.*;
 import mcmultipart.block.BlockCoverable;
@@ -149,8 +150,8 @@ public class BlockCable extends BlockCoverable {
     private boolean hasConnectionWith(IBlockAccess world, BlockPos pos, EnumFacing direction) {
         TileEntity facing = world.getTileEntity(pos.offset(direction));
 
-        boolean isConnectable = API.instance().getConnectableConditions().stream().anyMatch(p -> p.test(facing));
-        if (isConnectable) {
+        // We can always connect to an INetworkMaster, but INetworkNode needs to be checked for conductivity
+        if (facing instanceof INetworkMaster || (facing instanceof INetworkNode && ((INetworkNode) facing).canConduct(direction.getOpposite()))) {
             TileEntity tile = world.getTileEntity(pos);
 
             // Do not render a cable extension where our cable "head" is (e.g. importer, exporter, external storage heads).

--- a/src/main/java/com/raoulvdberge/refinedstorage/block/BlockCable.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/block/BlockCable.java
@@ -150,12 +150,17 @@ public class BlockCable extends BlockCoverable {
     private boolean hasConnectionWith(IBlockAccess world, BlockPos pos, EnumFacing direction) {
         TileEntity facing = world.getTileEntity(pos.offset(direction));
 
+        // No need to test anything else if the adjacent block has no TileEntity
+        if (facing == null) {
+            return false;
+        }
+
         // No need to check via getConnectableConditions() if the target block can't conduct back
         if (facing instanceof INetworkNode && !((INetworkNode) facing).canConduct(direction.getOpposite())) {
             return false;
         }
 
-        boolean isConnectable = API.instance().getConnectableConditions().stream().anyMatch(p -> p.test(facing));
+        boolean isConnectable = API.instance().hasConnectableConditions(facing);
         if (isConnectable) {
             TileEntity tile = world.getTileEntity(pos);
 


### PR DESCRIPTION
Check that facing blocks can conduct in each others direction when deciding on visually showing connection. (I'm looking at you BlockCable)

Replace equivalent code check in BlockCable that replicated canConduct in TileMultipartNode.

Add a hasConnectableConditions method to the public API to perform the getConnectableConditions stream test for mods that can't/don't do lambda functions. (java 1.7 and lower)  Consume that method in our own tests for block-to-block connectivity.

The RS network visual connectivity should be closer to the functional connectivity.