### PR TITLE
Fix missed node graph rebuild when placing node blocks on the far side of a conductive addon block implementing INetworkNode

### DIFF
--- a/src/main/java/com/raoulvdberge/refinedstorage/block/BlockCable.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/block/BlockCable.java
@@ -2,6 +2,7 @@ package com.raoulvdberge.refinedstorage.block;
 
 import com.raoulvdberge.refinedstorage.RS;
 import com.raoulvdberge.refinedstorage.api.network.INetworkMaster;
+import com.raoulvdberge.refinedstorage.api.network.INetworkNode;
 import com.raoulvdberge.refinedstorage.apiimpl.API;
 import com.raoulvdberge.refinedstorage.tile.*;
 import mcmultipart.block.BlockCoverable;
@@ -287,12 +288,12 @@ public class BlockCable extends BlockCoverable {
             for (EnumFacing facing : EnumFacing.VALUES) {
                 TileEntity tile = world.getTileEntity(pos.offset(facing));
 
-                if (tile instanceof TileNode && ((TileNode) tile).isConnected()) {
-                    ((TileNode) tile).getNetwork().getNodeGraph().rebuild();
+                if (tile instanceof INetworkNode && ((INetworkNode) tile).isConnected()) {
+                    ((INetworkNode) tile).getNetwork().getNodeGraph().rebuild();
 
                     break;
-                } else if (tile instanceof TileController) {
-                    ((TileController) tile).getNodeGraph().rebuild();
+                } else if (tile instanceof INetworkMaster) {
+                    ((INetworkMaster) tile).getNodeGraph().rebuild();
 
                     break;
                 }

--- a/src/main/java/com/raoulvdberge/refinedstorage/block/BlockNode.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/block/BlockNode.java
@@ -1,6 +1,7 @@
 package com.raoulvdberge.refinedstorage.block;
 
 import com.raoulvdberge.refinedstorage.api.network.INetworkMaster;
+import com.raoulvdberge.refinedstorage.api.network.INetworkNode;
 import com.raoulvdberge.refinedstorage.tile.TileController;
 import com.raoulvdberge.refinedstorage.tile.TileNode;
 import net.minecraft.block.properties.PropertyBool;
@@ -59,12 +60,12 @@ public abstract class BlockNode extends BlockBase {
             for (EnumFacing facing : EnumFacing.VALUES) {
                 TileEntity tile = world.getTileEntity(pos.offset(facing));
 
-                if (tile instanceof TileNode && ((TileNode) tile).isConnected()) {
-                    ((TileNode) tile).getNetwork().getNodeGraph().rebuild();
+                if (tile instanceof INetworkNode && ((INetworkNode) tile).isConnected()) {
+                    ((INetworkNode) tile).getNetwork().getNodeGraph().rebuild();
 
                     break;
-                } else if (tile instanceof TileController) {
-                    ((TileController) tile).getNodeGraph().rebuild();
+                } else if (tile instanceof INetworkMaster) {
+                    ((INetworkMaster) tile).getNodeGraph().rebuild();
 
                     break;
                 }


### PR DESCRIPTION
The current code in BlockCable.attemptConnect() and BlockNode.onBlockPlacedBy() test the TE's of surrounding blocks to see if they are network nodes and a node graph rebuild should take place on placement and after neighbors change.  The test is against TileNode which restricts the rebuild to adjacent RS blocks only, not addon blocks implementing INetworkNode on their TE.  Because of this, when BlockCable or BlockNode descendents are placed on the far side of a conductive addon block implementing INetworkNode, the node graph is not refreshed as it should be.