### PR TITLE
Add hasConnectableConditions() to API

### DIFF
--- a/src/main/java/com/raoulvdberge/refinedstorage/api/IRSAPI.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/api/IRSAPI.java
@@ -106,4 +106,9 @@ public interface IRSAPI {
      * @return a set with the predicates to check if a block is connectable
      */
     Set<Predicate<TileEntity>> getConnectableConditions();
+
+    /**
+     * @return whether the provided TileEntity matches any of the current connectable conditions
+     */
+    boolean hasConnectableConditions(TileEntity te);
 }

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/API.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/API.java
@@ -142,4 +142,9 @@ public class API implements IRSAPI {
             }
         }
     }
+
+    @Override
+    public boolean hasConnectableConditions(TileEntity te) {
+        return connectableConditions.stream().anyMatch(p -> p.test(te));
+    }
 }


### PR DESCRIPTION
Add API convenience function to test connectable conditions for mods consuming our API and still targeting java 1.7 for whatever reason (e.g. no lambda functions)