### PR TITLE
Fix CraftingTweaks Integration

### DIFF
--- a/src/main/java/com/raoulvdberge/refinedstorage/gui/grid/GuiGrid.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/gui/grid/GuiGrid.java
@@ -591,6 +591,7 @@ public class GuiGrid extends GuiBase implements IGridDisplay {
             updateJEI();
 
             sortItems();
+            keyHandled = true;
         } else if (searchField.isFocused() && (keyCode == Keyboard.KEY_UP || keyCode == Keyboard.KEY_DOWN || keyCode == Keyboard.KEY_RETURN)) {
             if (keyCode == Keyboard.KEY_UP) {
                 updateSearchHistory(-1);
@@ -603,10 +604,12 @@ public class GuiGrid extends GuiBase implements IGridDisplay {
                     searchField.setFocused(false);
                 }
             }
+            keyHandled = true;
         } else if (keyCode == RSKeyBindings.FOCUS_SEARCH_BAR.getKeyCode() && (grid.getSearchBoxMode() == NetworkNodeGrid.SEARCH_BOX_MODE_NORMAL || grid.getSearchBoxMode() == NetworkNodeGrid.SEARCH_BOX_MODE_JEI_SYNCHRONIZED)) {
             searchField.setFocused(!searchField.isFocused());
 
             saveHistory();
+            keyHandled = true;
         } else {
             super.keyTyped(character, keyCode);
         }

--- a/src/main/java/com/raoulvdberge/refinedstorage/integration/craftingtweaks/IntegrationCraftingTweaks.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/integration/craftingtweaks/IntegrationCraftingTweaks.java
@@ -1,8 +1,10 @@
 package com.raoulvdberge.refinedstorage.integration.craftingtweaks;
 
 import com.google.common.base.Function;
+import com.google.common.base.Predicate;
 import com.raoulvdberge.refinedstorage.block.GridType;
 import com.raoulvdberge.refinedstorage.container.ContainerGrid;
+import com.raoulvdberge.refinedstorage.container.slot.SlotGridCrafting;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.event.FMLInterModComms;
@@ -18,17 +20,29 @@ public final class IntegrationCraftingTweaks {
         NBTTagCompound tag = new NBTTagCompound();
 
         tag.setString("ContainerClass", ContainerGrid.class.getName());
-        tag.setString("ContainerCallback", ContainerCallback.class.getName());
-        tag.setInteger("GridSlotNumber", 36);
+        tag.setString("ValidContainerPredicate", ValidContainerPredicate.class.getName());
+        tag.setString("GetGridStartFunction", GetGridStartFunction.class.getName());
         tag.setString("AlignToGrid", "left");
 
-        FMLInterModComms.sendMessage(ID, "RegisterProviderV2", tag);
+        FMLInterModComms.sendMessage(ID, "RegisterProviderV3", tag);
     }
 
-    public static class ContainerCallback implements Function<ContainerGrid, Boolean> {
+    public static class ValidContainerPredicate implements Predicate<ContainerGrid> {
         @Override
-        public Boolean apply(ContainerGrid containerGrid) {
+        public boolean apply(ContainerGrid containerGrid) {
             return containerGrid.getGrid().getType() == GridType.CRAFTING;
+        }
+    }
+
+    public static class GetGridStartFunction implements Function<ContainerGrid, Integer> {
+        @Override
+        public Integer apply(ContainerGrid containerGrid) {
+            for(int i = 0; i < containerGrid.inventorySlots.size(); i++) {
+                if(containerGrid.inventorySlots.get(i) instanceof SlotGridCrafting) {
+                    return i;
+                }
+            }
+            return 0;
         }
     }
 }


### PR DESCRIPTION
Updated to latest Crafting Tweaks API. Buttons will now always appear next to the grid, no matter at what slot index it starts.

Also set `keyHandled = true` in `GuiGrid` to prevent the `KeyboardInputEvent.Post` event from firing, which will fix Crafting Tweaks hotkeys triggering when they shouldn't (Crafting Tweaks v7.1.7+).

What's not fixed is that the Crafting Tweaks buttons disappear when changing the grid size (they re-appear on the next `setWorldAndResolution` call, so on resizing the window or reopening the gui). I don't consider it a huge issue, but will fix that on my side later.