### PR TITLE
[Mc1.11] Add Forestry Bee support to filters

### DIFF
--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/util/Comparer.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/util/Comparer.java
@@ -99,7 +99,10 @@ public class Comparer implements IComparer {
                 return true;
             } else if (!left.hasTagCompound() && right.hasTagCompound() && right.getTagCompound().hasNoTags()) {
                 return true;
-            } else if (left.getTagCompound().hasKey("GEN")) {
+            } 	
+	     /* Forestry Bee Support
+	     Removes the GEN tag from NBT if present to allow for proper filtering of Forestry queen bees. */
+	     else if (left.getTagCompound().hasKey("GEN")) {
                 NBTTagCompound leftTag = left.getTagCompound().copy();
                 NBTTagCompound rightTag = right.getTagCompound().copy();
                 leftTag.removeTag("GEN");

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/util/Comparer.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/util/Comparer.java
@@ -4,6 +4,7 @@ import com.raoulvdberge.refinedstorage.RSUtils;
 import com.raoulvdberge.refinedstorage.api.util.IComparer;
 import com.raoulvdberge.refinedstorage.block.BlockNode;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumActionResult;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.oredict.OreDictionary;

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/util/Comparer.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/util/Comparer.java
@@ -98,7 +98,13 @@ public class Comparer implements IComparer {
                 return true;
             } else if (!left.hasTagCompound() && right.hasTagCompound() && right.getTagCompound().hasNoTags()) {
                 return true;
-            }
+            } else if (left.getTagCompound().hasKey("GEN")) {
+                NBTTagCompound leftTag = left.getTagCompound().copy();
+                NBTTagCompound rightTag = right.getTagCompound().copy();
+                leftTag.removeTag("GEN");
+                rightTag.removeTag("GEN");
+                return leftTag.equals(rightTag);
+			}
 
             return false;
         }

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/util/Comparer.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/util/Comparer.java
@@ -104,7 +104,7 @@ public class Comparer implements IComparer {
                 leftTag.removeTag("GEN");
                 rightTag.removeTag("GEN");
                 return leftTag.equals(rightTag);
-			}
+	    }
 
             return false;
         }

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/util/Comparer.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/util/Comparer.java
@@ -99,10 +99,8 @@ public class Comparer implements IComparer {
                 return true;
             } else if (!left.hasTagCompound() && right.hasTagCompound() && right.getTagCompound().hasNoTags()) {
                 return true;
-            } 	
-	     /* Forestry Bee Support
-	     Removes the GEN tag from NBT if present to allow for proper filtering of Forestry queen bees. */
-	     else if (left.getTagCompound().hasKey("GEN")) {
+            } else if (left.getTagCompound().hasKey("GEN")) { // Forestry Bee Support
+		// Removes the GEN tag from NBT if present to allow for proper filtering of Forestry queen bees.
                 NBTTagCompound leftTag = left.getTagCompound().copy();
                 NBTTagCompound rightTag = right.getTagCompound().copy();
                 leftTag.removeTag("GEN");

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/util/Comparer.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/util/Comparer.java
@@ -99,7 +99,7 @@ public class Comparer implements IComparer {
                 return true;
             } else if (!left.hasTagCompound() && right.hasTagCompound() && right.getTagCompound().hasNoTags()) {
                 return true;
-            } else if (left.getTagCompound().hasKey("GEN")) { // Forestry Bee Support
+            } else if (left.getTagCompound().hasKey("GEN")) {
 		// Removes the GEN tag from NBT if present to allow for proper filtering of Forestry queen bees.
                 NBTTagCompound leftTag = left.getTagCompound().copy();
                 NBTTagCompound rightTag = right.getTagCompound().copy();


### PR DESCRIPTION
The only problem with automating forestry bees is that the queens have an NBT tag that increments their generations, making the result technically a different item. This extra comparison checks to see if the item coming in has this GEN tag, and if so, ignores the GEN tag before comparing everything else.