### PR TITLE
Better implementation for crafting grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 1.5.21
 - Updated Portuguese (Brazilian) translation (Pinz714)
 - Fixed crash with External Storage (raoulvdberge)
+- Attempted fix for stack-crafting causing lag on a dedicated server (Lordmau5)
 
 ### 1.5.20
 - Restore MC 1.12.0 compatibility (raoulvdberge)

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/network/node/NetworkNodeGrid.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/network/node/NetworkNodeGrid.java
@@ -246,8 +246,7 @@ public class NetworkNodeGrid extends NetworkNode implements IGrid {
 
         if (currentRecipe == null) {
             result.setInventorySlotContents(0, ItemStack.EMPTY);
-        }
-        else {
+        } else {
             result.setInventorySlotContents(0, currentRecipe.getCraftingResult(matrix));
         }
 

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/network/node/NetworkNodeGrid.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/network/node/NetworkNodeGrid.java
@@ -27,6 +27,7 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.*;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
+import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
@@ -67,6 +68,7 @@ public class NetworkNodeGrid extends NetworkNode implements IGrid {
             onCraftingMatrixChanged();
         }
     };
+    private IRecipe currentRecipe;
     private InventoryCrafting matrix = new InventoryCrafting(craftingContainer, 3, 3);
     private InventoryCraftResult result = new InventoryCraftResult();
     private ItemHandlerBase matrixProcessing = new ItemHandlerBase(9 * 2, new ItemHandlerListenerNetworkNode(this));
@@ -238,7 +240,16 @@ public class NetworkNodeGrid extends NetworkNode implements IGrid {
 
     @Override
     public void onCraftingMatrixChanged() {
-        result.setInventorySlotContents(0, CraftingManager.findMatchingResult(matrix, world));
+        if (currentRecipe == null || !currentRecipe.matches(matrix, world)) {
+            currentRecipe = CraftingManager.findMatchingRecipe(matrix, world);
+        }
+
+        if (currentRecipe == null) {
+            result.setInventorySlotContents(0, ItemStack.EMPTY);
+        }
+        else {
+            result.setInventorySlotContents(0, currentRecipe.getCraftingResult(matrix));
+        }
 
         markDirty();
     }


### PR DESCRIPTION
Tackles #1368 and tries to fix it by caching the recipe to not call "CraftingManager.findMatchingResult" every single time it tries to craft