### PR TITLE
Fix issue #1511 . Use hashmap to optimize the performance in building CraftingPatternChainList

### DIFF
--- a/src/main/java/com/raoulvdberge/refinedstorage/api/autocrafting/ICraftingPattern.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/api/autocrafting/ICraftingPattern.java
@@ -14,7 +14,10 @@ public interface ICraftingPattern {
      * @return the {@link ICraftingPatternContainer} where the pattern is in
      */
     ICraftingPatternContainer getContainer();
-
+    
+    public int hashCode();
+    
+    public boolean equals (Object obj);
     /**
      * @return the crafting pattern stack
      */

--- a/src/main/java/com/raoulvdberge/refinedstorage/api/autocrafting/ICraftingPattern.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/api/autocrafting/ICraftingPattern.java
@@ -15,9 +15,6 @@ public interface ICraftingPattern {
      */
     ICraftingPatternContainer getContainer();
     
-    public int hashCode();
-    
-    public boolean equals (Object obj);
     /**
      * @return the crafting pattern stack
      */

--- a/src/main/java/com/raoulvdberge/refinedstorage/api/autocrafting/ICraftingPattern.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/api/autocrafting/ICraftingPattern.java
@@ -14,7 +14,7 @@ public interface ICraftingPattern {
      * @return the {@link ICraftingPatternContainer} where the pattern is in
      */
     ICraftingPatternContainer getContainer();
-    
+
     /**
      * @return the crafting pattern stack
      */

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/CraftingPattern.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/CraftingPattern.java
@@ -289,6 +289,7 @@ public class CraftingPattern implements ICraftingPattern {
     			itemHashCode = mItemStack.getCount();
     			itemHashCode = itemHashCode * 31 + mItemStack.getItem().hashCode();
     			itemHashCode = itemHashCode * 31 + mItemStack.getItemDamage();
+    			itemHashCode = itemHashCode * 31 + Objects.hashCode(mItemStack.getTagCompound());
     			hashCodeCached = hashCodeCached * 31 + itemHashCode;
     		}
     	}

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/CraftingPattern.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/CraftingPattern.java
@@ -28,7 +28,8 @@ public class CraftingPattern implements ICraftingPattern {
     private List<List<ItemStack>> oreInputs = new ArrayList<>();
     private List<ItemStack> outputs = new ArrayList<>();
     private List<ItemStack> byproducts = new ArrayList<>();
-
+    private Integer hashCodeCached = null;
+    
     public CraftingPattern(World world, ICraftingPatternContainer container, ItemStack stack) {
         this.container = container;
         this.stack = Comparer.stripTags(stack);
@@ -276,23 +277,22 @@ public class CraftingPattern implements ICraftingPattern {
     
     @Override
     public boolean equals (Object obj) {
-    	return this==obj || (obj instanceof ICraftingPattern && this.alike((ICraftingPattern)obj));
+    	return this == obj || (obj instanceof ICraftingPattern && this.alike((ICraftingPattern)obj));
     }
     
-    Integer hashCode;
     @Override
     public int hashCode() {
-    	if(hashCode==null){
-    		hashCode=0;
-    		for(ItemStack mItemStack : this.getOutputs()){
-    			int itemHashCode=0;
-    			itemHashCode=mItemStack.getCount();
-    			itemHashCode=itemHashCode*31+mItemStack.getItem().hashCode();
-    			itemHashCode=itemHashCode*31+mItemStack.getItemDamage();
-    			hashCode=hashCode*31+itemHashCode;
+    	if (hashCodeCached == null) {
+    		hashCodeCached = 0;
+    		for (ItemStack mItemStack : this.getOutputs()) {
+    			int itemHashCode = 0;
+    			itemHashCode = mItemStack.getCount();
+    			itemHashCode = itemHashCode * 31 + mItemStack.getItem().hashCode();
+    			itemHashCode = itemHashCode * 31 + mItemStack.getItemDamage();
+    			hashCodeCached = hashCodeCached * 31 + itemHashCode;
     		}
     	}
-    	return hashCode;
+    	return hashCodeCached;
     }
     
     @Override

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/CraftingPattern.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/CraftingPattern.java
@@ -277,22 +277,22 @@ public class CraftingPattern implements ICraftingPattern {
     
     @Override
     public boolean equals (Object obj) {
-        return this == obj || (obj instanceof ICraftingPattern && this.alike((ICraftingPattern)obj));
+        return this == obj || (obj instanceof ICraftingPattern && this.alike((ICraftingPattern) obj));
     }
     
     @Override
     public int hashCode() {
         if (hashCodeCached == null) {
             hashCodeCached = 0;
-            for (ItemStack mItemStack : this.getOutputs()) {
+            for (ItemStack outputItemStack : this.getOutputs()) {
                 int itemHashCode = 0;
-                itemHashCode = mItemStack.getCount();
-                itemHashCode = itemHashCode * 31 + mItemStack.getItem().hashCode();
-                itemHashCode = itemHashCode * 31 + mItemStack.getItemDamage();
-                itemHashCode = itemHashCode * 31 + Objects.hashCode(mItemStack.getTagCompound());
+                itemHashCode = outputItemStack.getCount();
+                itemHashCode = itemHashCode * 31 + outputItemStack.getItem().hashCode();
+                itemHashCode = itemHashCode * 31 + outputItemStack.getItemDamage();
+                itemHashCode = itemHashCode * 31 + Objects.hashCode(outputItemStack.getTagCompound());
                 hashCodeCached = hashCodeCached * 31 + itemHashCode;
-                }
             }
+        }
         return hashCodeCached;
     }
     

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/CraftingPattern.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/CraftingPattern.java
@@ -273,7 +273,24 @@ public class CraftingPattern implements ICraftingPattern {
             ", byproducts=" + byproducts +
             '}';
     }
-
+    
+    @Override
+    public boolean equals (Object obj) {
+    	return this==obj || (obj instanceof ICraftingPattern && this.alike((ICraftingPattern)obj));
+    }
+    
+    String toHash;
+    @Override
+    public int hashCode() {
+    	if(toHash==null){
+    		toHash=new String();
+    		for(ItemStack mItemStack : this.getOutputs()){
+    			toHash+=mItemStack.toString()+" ";
+    		}
+    	}
+    	return toHash.hashCode();
+    }
+    
     @Override
     public boolean alike(ICraftingPattern other) {
         if (other == this) {

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/CraftingPattern.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/CraftingPattern.java
@@ -277,23 +277,23 @@ public class CraftingPattern implements ICraftingPattern {
     
     @Override
     public boolean equals (Object obj) {
-    	return this == obj || (obj instanceof ICraftingPattern && this.alike((ICraftingPattern)obj));
+        return this == obj || (obj instanceof ICraftingPattern && this.alike((ICraftingPattern)obj));
     }
     
     @Override
     public int hashCode() {
-    	if (hashCodeCached == null) {
-    		hashCodeCached = 0;
-    		for (ItemStack mItemStack : this.getOutputs()) {
-    			int itemHashCode = 0;
-    			itemHashCode = mItemStack.getCount();
-    			itemHashCode = itemHashCode * 31 + mItemStack.getItem().hashCode();
-    			itemHashCode = itemHashCode * 31 + mItemStack.getItemDamage();
-    			itemHashCode = itemHashCode * 31 + Objects.hashCode(mItemStack.getTagCompound());
-    			hashCodeCached = hashCodeCached * 31 + itemHashCode;
-    		}
-    	}
-    	return hashCodeCached;
+        if (hashCodeCached == null) {
+            hashCodeCached = 0;
+            for (ItemStack mItemStack : this.getOutputs()) {
+                int itemHashCode = 0;
+                itemHashCode = mItemStack.getCount();
+                itemHashCode = itemHashCode * 31 + mItemStack.getItem().hashCode();
+                itemHashCode = itemHashCode * 31 + mItemStack.getItemDamage();
+                itemHashCode = itemHashCode * 31 + Objects.hashCode(mItemStack.getTagCompound());
+                hashCodeCached = hashCodeCached * 31 + itemHashCode;
+                }
+            }
+        return hashCodeCached;
     }
     
     @Override

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/CraftingPattern.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/CraftingPattern.java
@@ -279,16 +279,20 @@ public class CraftingPattern implements ICraftingPattern {
     	return this==obj || (obj instanceof ICraftingPattern && this.alike((ICraftingPattern)obj));
     }
     
-    String toHash;
+    Integer hashCode;
     @Override
     public int hashCode() {
-    	if(toHash==null){
-    		toHash=new String();
+    	if(hashCode==null){
+    		hashCode=0;
     		for(ItemStack mItemStack : this.getOutputs()){
-    			toHash+=mItemStack.toString()+" ";
+    			int itemHashCode=0;
+    			itemHashCode=mItemStack.getCount();
+    			itemHashCode=itemHashCode*31+mItemStack.getItem().hashCode();
+    			itemHashCode=itemHashCode*31+mItemStack.getItemDamage();
+    			hashCode=hashCode*31+itemHashCode;
     		}
     	}
-    	return toHash.hashCode();
+    	return hashCode;
     }
     
     @Override

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/CraftingPatternChainList.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/CraftingPatternChainList.java
@@ -16,19 +16,18 @@ public class CraftingPatternChainList implements Iterable<CraftingPatternChainLi
     Map<ICraftingPattern, CraftingPatternChain> innerChainMap = new HashMap<>();
     
     public void add(ICraftingPattern pattern) {
-    	CraftingPatternChain chain = innerChainMap.get(pattern);
-    	if (chain == null) {
-    		chain = new CraftingPatternChain(pattern);
-    		innerChain.add(chain);
-    		innerChainMap.put(pattern, chain);
-    	} else {
-    		if (!chain.add(pattern)) {
-    			chain = new CraftingPatternChain(pattern);
-        		innerChain.add(chain);
-        		innerChainMap.put(pattern, chain);
-    		}
-    		
-    	}
+        CraftingPatternChain chain = innerChainMap.get(pattern);
+        if (chain == null) {
+            chain = new CraftingPatternChain(pattern);
+            innerChain.add(chain);
+            innerChainMap.put(pattern, chain);
+        } else {
+            if (!chain.add(pattern)) {
+                chain = new CraftingPatternChain(pattern);
+                innerChain.add(chain);
+                innerChainMap.put(pattern, chain);
+            }	
+        }
     }
 
     public void addAll(Collection<ICraftingPattern> patterns) {
@@ -45,8 +44,8 @@ public class CraftingPatternChainList implements Iterable<CraftingPatternChainLi
     }
 
     public void clear() {
-    	innerChain.clear();
-    	innerChainMap.clear();
+        innerChain.clear();
+        innerChainMap.clear();
     }
 
     public static class CraftingPatternChain implements ICraftingPatternChain {

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/CraftingPatternChainList.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/CraftingPatternChainList.java
@@ -5,26 +5,24 @@ import com.raoulvdberge.refinedstorage.api.autocrafting.ICraftingPatternChain;
 
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 public class CraftingPatternChainList implements Iterable<CraftingPatternChainList.CraftingPatternChain> {
     LinkedList<CraftingPatternChain> innerChain = new LinkedList<>();
-    Map<ICraftingPattern,CraftingPatternChain>innerChainMap=new HashMap<>();
+    Map<ICraftingPattern, CraftingPatternChain> innerChainMap = new HashMap<>();
     public void add(ICraftingPattern pattern) {
-    	CraftingPatternChain chain=innerChainMap.get(pattern);
-    	if(chain==null){
-    		chain=new CraftingPatternChain(pattern);
+    	CraftingPatternChain chain = innerChainMap.get(pattern);
+    	if(chain == null){
+    		chain = new CraftingPatternChain(pattern);
     		innerChain.add(chain);
     		innerChainMap.put(pattern, chain);
     	} else {
     		if(!chain.add(pattern)){
-    			chain=new CraftingPatternChain(pattern);
+    			chain = new CraftingPatternChain(pattern);
         		innerChain.add(chain);
         		innerChainMap.put(pattern, chain);
     		}

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/CraftingPatternChainList.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/CraftingPatternChainList.java
@@ -14,14 +14,15 @@ import java.util.stream.Collectors;
 public class CraftingPatternChainList implements Iterable<CraftingPatternChainList.CraftingPatternChain> {
     LinkedList<CraftingPatternChain> innerChain = new LinkedList<>();
     Map<ICraftingPattern, CraftingPatternChain> innerChainMap = new HashMap<>();
+    
     public void add(ICraftingPattern pattern) {
     	CraftingPatternChain chain = innerChainMap.get(pattern);
-    	if(chain == null){
+    	if (chain == null) {
     		chain = new CraftingPatternChain(pattern);
     		innerChain.add(chain);
     		innerChainMap.put(pattern, chain);
     	} else {
-    		if(!chain.add(pattern)){
+    		if (!chain.add(pattern)) {
     			chain = new CraftingPatternChain(pattern);
         		innerChain.add(chain);
         		innerChainMap.put(pattern, chain);

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/CraftingPatternChainList.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/CraftingPatternChainList.java
@@ -4,22 +4,32 @@ import com.raoulvdberge.refinedstorage.api.autocrafting.ICraftingPattern;
 import com.raoulvdberge.refinedstorage.api.autocrafting.ICraftingPatternChain;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class CraftingPatternChainList implements Iterable<CraftingPatternChainList.CraftingPatternChain> {
     LinkedList<CraftingPatternChain> innerChain = new LinkedList<>();
-
+    Map<ICraftingPattern,CraftingPatternChain>innerChainMap=new HashMap<>();
     public void add(ICraftingPattern pattern) {
-        int i = 0;
-        while (i < innerChain.size() && !innerChain.get(i).add(pattern)) {
-            i++;
-        }
-        if (i == innerChain.size()) {
-            innerChain.add(new CraftingPatternChain(pattern));
-        }
+    	CraftingPatternChain chain=innerChainMap.get(pattern);
+    	if(chain==null){
+    		chain=new CraftingPatternChain(pattern);
+    		innerChain.add(chain);
+    		innerChainMap.put(pattern, chain);
+    	} else {
+    		if(!chain.add(pattern)){
+    			chain=new CraftingPatternChain(pattern);
+        		innerChain.add(chain);
+        		innerChainMap.put(pattern, chain);
+    		}
+    		
+    	}
     }
 
     public void addAll(Collection<ICraftingPattern> patterns) {
@@ -36,7 +46,8 @@ public class CraftingPatternChainList implements Iterable<CraftingPatternChainLi
     }
 
     public void clear() {
-        innerChain.clear();
+    	innerChain.clear();
+    	innerChainMap.clear();
     }
 
     public static class CraftingPatternChain implements ICraftingPatternChain {


### PR DESCRIPTION
Fix issue #1511 .
The original implementation has a complexity of O(n^2) to build a CraftingPatternChainList when a network starts. For each crafting pattern, it need to be compared with all the patterns already in the List, which may cost a very long time when a network has a large amount of patterns. Especially in the server it may cause the players to be disconnected due to the timeout.  With a hash map the complexity can be reduced to O(n), which means at most n times of comparison are needed.