### PR TITLE
Fixed issue with pattern overwriting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 1.5.32
 - Added Spanish translation (Samuelrock)
+- Fixed issue where the Pattern Grid can only overwrite patterns when blank ones are present (ineternet)
 
 ### 1.5.31
 - Improved the "cannot craft! loop in processing..." error message (raoulvdberge)

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/network/node/NetworkNodeGrid.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/network/node/NetworkNodeGrid.java
@@ -455,7 +455,8 @@ public class NetworkNodeGrid extends NetworkNode implements IGrid {
     }
 
     public void onCreatePattern() {
-        if (canCreatePattern()) {
+        if (
+        ) {
             if (patterns.getStackInSlot(1).isEmpty()) {
                 patterns.extractItem(0, 1, false);
             }
@@ -491,9 +492,13 @@ public class NetworkNodeGrid extends NetworkNode implements IGrid {
             patterns.setStackInSlot(1, pattern);
         }
     }
+    
+    private boolean patternAvailable() {
+        return patterns.getStackInSlot(0).isEmpty() && patterns.getStackInSlot(1).isEmpty();
+    }
 
     public boolean canCreatePattern() {
-        if (patterns.getStackInSlot(0).isEmpty()) {
+        if (!patternAvailable()) {
             return false;
         }
 
@@ -515,7 +520,7 @@ public class NetworkNodeGrid extends NetworkNode implements IGrid {
 
             return inputsFilled > 0 && outputsFilled > 0;
         } else {
-            return !result.getStackInSlot(0).isEmpty();
+            return patternAvailable();
         }
     }
 

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/network/node/NetworkNodeGrid.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/network/node/NetworkNodeGrid.java
@@ -455,8 +455,7 @@ public class NetworkNodeGrid extends NetworkNode implements IGrid {
     }
 
     public void onCreatePattern() {
-        if (
-        ) {
+        if (canCreatePattern()) {
             if (patterns.getStackInSlot(1).isEmpty()) {
                 patterns.extractItem(0, 1, false);
             }

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/network/node/NetworkNodeGrid.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/network/node/NetworkNodeGrid.java
@@ -492,12 +492,12 @@ public class NetworkNodeGrid extends NetworkNode implements IGrid {
         }
     }
     
-    private boolean patternAvailable() {
+    private boolean isPatternAvailable() {
         return !(patterns.getStackInSlot(0).isEmpty() && patterns.getStackInSlot(1).isEmpty());
     }
 
     public boolean canCreatePattern() {
-        if (!patternAvailable()) {
+        if (!isPatternAvailable()) {
             return false;
         }
 
@@ -519,7 +519,7 @@ public class NetworkNodeGrid extends NetworkNode implements IGrid {
 
             return inputsFilled > 0 && outputsFilled > 0;
         } else {
-            return patternAvailable();
+            return isPatternAvailable();
         }
     }
 

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/network/node/NetworkNodeGrid.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/network/node/NetworkNodeGrid.java
@@ -493,7 +493,7 @@ public class NetworkNodeGrid extends NetworkNode implements IGrid {
     }
     
     private boolean patternAvailable() {
-        return patterns.getStackInSlot(0).isEmpty() && patterns.getStackInSlot(1).isEmpty();
+        return !(patterns.getStackInSlot(0).isEmpty() && patterns.getStackInSlot(1).isEmpty());
     }
 
     public boolean canCreatePattern() {


### PR DESCRIPTION
Pattern overwriting if the blank pattern (top slot in the pattern slots) slot was empty. Fixed this by only considering a recipe invalid if there are *absolutely no* patterns available, meaning none in top and none in bottom.