### PR TITLE
Changed item quantity of a craftable item to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 1.5.32
 - Added Spanish translation (Samuelrock)
 - Fixed issue where the Pattern Grid can only overwrite patterns when blank ones are present (ineternet)
+- Changed stack quantity of craftable items from 1 to 0 to fix Quantity Sorting (ineternet)
 
 ### 1.5.31
 - Improved the "cannot craft! loop in processing..." error message (raoulvdberge)

--- a/src/main/java/com/raoulvdberge/refinedstorage/gui/grid/sorting/GridSortingQuantity.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/gui/grid/sorting/GridSortingQuantity.java
@@ -7,8 +7,8 @@ import com.raoulvdberge.refinedstorage.gui.grid.stack.GridStackItem;
 public class GridSortingQuantity extends GridSorting {
     @Override
     public int compare(IGridStack left, IGridStack right) {
-        int leftSize = isStackCraftableEmpty(left) ? 0 : left.getQuantity();
-        int rightSize = isStackCraftableEmpty(right) ? 0 : right.getQuantity();
+        int leftSize = left.getQuantity();
+        int rightSize = right.getQuantity();
 
         if (leftSize != rightSize) {
             if (sortingDirection == IGrid.SORTING_DIRECTION_ASCENDING) {
@@ -19,11 +19,5 @@ public class GridSortingQuantity extends GridSorting {
         }
 
         return 0;
-    }
-    
-    private boolean isStackCraftableEmpty(IGridStack stack) {
-        if (!(stack instanceof GridStackItem))
-            return false;
-        return ((GridStackItem)stack).doesDisplayCraftText();
     }
 }

--- a/src/main/java/com/raoulvdberge/refinedstorage/gui/grid/sorting/GridSortingQuantity.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/gui/grid/sorting/GridSortingQuantity.java
@@ -2,12 +2,13 @@ package com.raoulvdberge.refinedstorage.gui.grid.sorting;
 
 import com.raoulvdberge.refinedstorage.api.network.grid.IGrid;
 import com.raoulvdberge.refinedstorage.gui.grid.stack.IGridStack;
+import com.raoulvdberge.refinedstorage.gui.grid.stack.GridStackItem;
 
 public class GridSortingQuantity extends GridSorting {
     @Override
     public int compare(IGridStack left, IGridStack right) {
-        int leftSize = left.getQuantity();
-        int rightSize = right.getQuantity();
+        int leftSize = isStackCraftableEmpty(left) ? 0 : left.getQuantity();
+        int rightSize = isStackCraftableEmpty(right) ? 0 : right.getQuantity();
 
         if (leftSize != rightSize) {
             if (sortingDirection == IGrid.SORTING_DIRECTION_ASCENDING) {
@@ -18,5 +19,11 @@ public class GridSortingQuantity extends GridSorting {
         }
 
         return 0;
+    }
+    
+    private boolean isStackCraftableEmpty(IGridStack stack) {
+        if (!(stack instanceof GridStackItem))
+            return false;
+        return ((GridStackItem)stack).doesDisplayCraftText();
     }
 }

--- a/src/main/java/com/raoulvdberge/refinedstorage/gui/grid/sorting/GridSortingQuantity.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/gui/grid/sorting/GridSortingQuantity.java
@@ -2,7 +2,6 @@ package com.raoulvdberge.refinedstorage.gui.grid.sorting;
 
 import com.raoulvdberge.refinedstorage.api.network.grid.IGrid;
 import com.raoulvdberge.refinedstorage.gui.grid.stack.IGridStack;
-import com.raoulvdberge.refinedstorage.gui.grid.stack.GridStackItem;
 
 public class GridSortingQuantity extends GridSorting {
     @Override

--- a/src/main/java/com/raoulvdberge/refinedstorage/gui/grid/stack/GridStackItem.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/gui/grid/stack/GridStackItem.java
@@ -114,7 +114,7 @@ public class GridStackItem implements IGridStack {
 
     @Override
     public int getQuantity() {
-        return stack.getCount();
+        return doesDisplayCraftText() ? 0 : stack.getCount();
     }
 
     @Override


### PR DESCRIPTION
Fix for #1604 
Whenever a system has none of a specific item but the ability to craft it, the grid saves the quantity as 1. Quantity sorting would make use of this and sort it alphabetically together with other quantity 1 items. This change should make quantity sorting think craftable items have a quantity of 0, making all of them appear behind itemstacks with the quantity 1 (or higher).