### PR TITLE
Stop fluid stacks from displaying "0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed not being able to extract half a stack of items with max stack size 1 in Grid when using right click (raoulvdberge)
 - Fixed 2 same stacks using capabilities without NBT tag not treated equal (raoulvdberge)
 - Changed stack quantity of craftable items from 1 to 0 to fix Quantity Sorting (ineternet)
+- Changed fluid stack amount to not display "0" anymore (ineternet)
 
 ### 1.5.31
 - Improved the "cannot craft! loop in processing..." error message (raoulvdberge)

--- a/src/main/java/com/raoulvdberge/refinedstorage/gui/grid/stack/GridStackFluid.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/gui/grid/stack/GridStackFluid.java
@@ -63,7 +63,10 @@ public class GridStackFluid implements IGridStack {
     public void draw(GuiBase gui, int x, int y) {
         GuiBase.FLUID_RENDERER.draw(gui.mc, x, y, stack);
 
-        gui.drawQuantity(x, y, API.instance().getQuantityFormatter().formatWithUnits((int) ((float) stack.amount / 1000F)));
+        int amount = (int) ((float) stack.amount / 1000F));
+        String formattedAmount = amount >= 1 ? API.instance().getQuantityFormatter().formatWithUnits(amount) : "<1";
+        
+        gui.drawQuantity(x, y, formattedAmount);
     }
 
     @Override

--- a/src/main/java/com/raoulvdberge/refinedstorage/gui/grid/stack/GridStackFluid.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/gui/grid/stack/GridStackFluid.java
@@ -63,8 +63,9 @@ public class GridStackFluid implements IGridStack {
     public void draw(GuiBase gui, int x, int y) {
         GuiBase.FLUID_RENDERER.draw(gui.mc, x, y, stack);
 
-        int amount = (int) ((float) stack.amount / 1000F);
-        String formattedAmount = amount >= 1 ? API.instance().getQuantityFormatter().formatWithUnits(amount) : "<1";
+        float amountRaw = ((float) stack.amount / 1000F);
+        int amount = (int) amountRaw;
+        String formattedAmount = amount >= 1 ? API.instance().getQuantityFormatter().formatWithUnits(amount) : String.format("%.1f", amountRaw);
         
         gui.drawQuantity(x, y, formattedAmount);
     }

--- a/src/main/java/com/raoulvdberge/refinedstorage/gui/grid/stack/GridStackFluid.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/gui/grid/stack/GridStackFluid.java
@@ -63,7 +63,7 @@ public class GridStackFluid implements IGridStack {
     public void draw(GuiBase gui, int x, int y) {
         GuiBase.FLUID_RENDERER.draw(gui.mc, x, y, stack);
 
-        int amount = (int) ((float) stack.amount / 1000F));
+        int amount = (int) ((float) stack.amount / 1000F);
         String formattedAmount = amount >= 1 ? API.instance().getQuantityFormatter().formatWithUnits(amount) : "<1";
         
         gui.drawQuantity(x, y, formattedAmount);


### PR DESCRIPTION
Could be confusing. Instead they will display "<1", to indicate the stack isnt empty but contains less than a bucket.