### PR TITLE
Allow crafters to be daisy-chained

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@ run/
 .idea/
 out/
 translation-diff.diff
-/bin/

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ run/
 .idea/
 out/
 translation-diff.diff
+/bin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Refined Storage Changelog
 
+### 1.5.34
+- Allow crafters to be daisy-chained (tomKPZ)
+
 ### 1.5.33
 - Added Crafter Manager (raoulvdberge)
 - Patterns in the Crafter slots now automatically render the output without pressing shift (raoulvdberge)
@@ -10,7 +13,6 @@
 - Fixed Grid not always using all combinations when using JEI autocompletion (raoulvdberge)
 - Increased Grid performance (raoulvdberge)
 - Various internal refactors (raoulvdberge)
-- Allow crafters to be daisy-chained (tomKPZ)
 
 ### 1.5.32
 - Added Spanish translation (Samuelrock)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed Grid not always using all combinations when using JEI autocompletion (raoulvdberge)
 - Increased Grid performance (raoulvdberge)
 - Various internal refactors (raoulvdberge)
+- Allow crafters to be daisy-chained (tomKPZ)
 
 ### 1.5.32
 - Added Spanish translation (Samuelrock)

--- a/src/main/java/com/raoulvdberge/refinedstorage/api/autocrafting/ICraftingManager.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/api/autocrafting/ICraftingManager.java
@@ -51,6 +51,12 @@ public interface ICraftingManager {
     boolean isContainerBlocked(UUID blockee);
 
     /**
+     * @param container the container to set the blocking state for
+     * @param blocked whether the container should be blocked
+     */
+    void setContainerBlocked(ICraftingPatternContainer container, boolean blocked);
+
+    /**
      * Adds a crafting task.
      *
      * @param task the task to add

--- a/src/main/java/com/raoulvdberge/refinedstorage/api/autocrafting/ICraftingManager.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/api/autocrafting/ICraftingManager.java
@@ -12,6 +12,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
 /**
  * The crafting manager handles the storing, updating, adding and deleting of crafting tasks in a network.
@@ -31,6 +33,11 @@ public interface ICraftingManager {
      * @return named crafting pattern containers
      */
     Map<String, List<IItemHandlerModifiable>> getNamedContainers();
+
+    /**
+     * @return all crafting pattern containers that are blocking, safe to modify this set
+     */
+    Set<UUID> getBlockingContainers();
 
     /**
      * Adds a crafting task.

--- a/src/main/java/com/raoulvdberge/refinedstorage/api/autocrafting/ICraftingManager.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/api/autocrafting/ICraftingManager.java
@@ -12,7 +12,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 
 /**

--- a/src/main/java/com/raoulvdberge/refinedstorage/api/autocrafting/ICraftingManager.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/api/autocrafting/ICraftingManager.java
@@ -35,9 +35,21 @@ public interface ICraftingManager {
     Map<String, List<IItemHandlerModifiable>> getNamedContainers();
 
     /**
-     * @return all crafting pattern containers that are blocking, safe to modify this set
+     * @param blocker the container that is blocking another container
+     * @param blockee the container being blocked, may be the same as blocker
      */
-    Set<UUID> getBlockingContainers();
+    void addContainerBlock(UUID blocker, UUID blockee);
+
+    /**
+     * @param blocker the container that is blocking another container
+     */
+    void removeContainerBlock(UUID blocker);
+
+    /**
+     * @param blockee the container to check
+     * @return whether the container is blocked
+     */
+    boolean isContainerBlocked(UUID blockee);
 
     /**
      * Adds a crafting task.

--- a/src/main/java/com/raoulvdberge/refinedstorage/api/autocrafting/ICraftingPatternContainer.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/api/autocrafting/ICraftingPatternContainer.java
@@ -8,6 +8,8 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 
 import javax.annotation.Nullable;
 
+import com.raoulvdberge.refinedstorage.api.network.INetwork;
+
 import java.util.List;
 import java.util.UUID;
 
@@ -82,9 +84,10 @@ public interface ICraftingPatternContainer {
     boolean isBlocked();
 
     /**
+     * @param network the network associated with this container
      * @param blocked whether the container should be blocked
      */
-    void setBlocked(boolean blocked);
+    void setBlocked(INetwork network, boolean blocked);
 
     /**
      * @param blockedOn the descendant that this container is blocked on

--- a/src/main/java/com/raoulvdberge/refinedstorage/api/autocrafting/ICraftingPatternContainer.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/api/autocrafting/ICraftingPatternContainer.java
@@ -1,6 +1,7 @@
 package com.raoulvdberge.refinedstorage.api.autocrafting;
 
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
@@ -35,6 +36,11 @@ public interface ICraftingPatternContainer {
     TileEntity getFacingTile();
 
     /**
+     * @return the direction to the facing tile
+     */
+    EnumFacing getDirection();
+
+    /**
      * @return the patterns stored in this container
      */
     List<ICraftingPattern> getPatterns();
@@ -61,8 +67,9 @@ public interface ICraftingPatternContainer {
 
     /**
      * Containers may be daisy-chained together.  If this container points to
-     * another one, gets the last container in the chain.  Otherwise, this
-     * container is the last in the chain.
+     * another one, gets the last container in the chain.  If containers are
+     * not daisy-chained, returns this container.  If there was a container
+     * loop, returns null.
      *
      * @return the root pattern container
      */
@@ -83,4 +90,10 @@ public interface ICraftingPatternContainer {
      * @param blockedOn the descendant that this container is blocked on
      */
     void setBlockedOn(UUID blockedOn);
+
+    /**
+     * @return the UUID of the container that this container is blocked on
+     */
+    @Nullable
+    UUID getBlockedOn();
 }

--- a/src/main/java/com/raoulvdberge/refinedstorage/api/autocrafting/ICraftingPatternContainer.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/api/autocrafting/ICraftingPatternContainer.java
@@ -8,8 +8,6 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 
 import javax.annotation.Nullable;
 
-import com.raoulvdberge.refinedstorage.api.network.INetwork;
-
 import java.util.List;
 import java.util.UUID;
 
@@ -69,25 +67,19 @@ public interface ICraftingPatternContainer {
 
     /**
      * Containers may be daisy-chained together.  If this container points to
-     * another one, gets the last container in the chain.  If containers are
+     * another one, gets the root container in the chain.  If containers are
      * not daisy-chained, returns this container.  If there was a container
      * loop, returns null.
      *
      * @return the root pattern container
      */
     @Nullable
-    ICraftingPatternContainer getProxyPatternContainer();
+    ICraftingPatternContainer getRootContainer();
 
     /**
      * @return true if this container or its proxy is blocked, false otherwise
      */
     boolean isBlocked();
-
-    /**
-     * @param network the network associated with this container
-     * @param blocked whether the container should be blocked
-     */
-    void setBlocked(INetwork network, boolean blocked);
 
     /**
      * @return the UUID of this container

--- a/src/main/java/com/raoulvdberge/refinedstorage/api/autocrafting/ICraftingPatternContainer.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/api/autocrafting/ICraftingPatternContainer.java
@@ -90,13 +90,7 @@ public interface ICraftingPatternContainer {
     void setBlocked(INetwork network, boolean blocked);
 
     /**
-     * @param blockedOn the descendant that this container is blocked on
+     * @return the UUID of this container
      */
-    void setBlockedOn(UUID blockedOn);
-
-    /**
-     * @return the UUID of the container that this container is blocked on
-     */
-    @Nullable
-    UUID getBlockedOn();
+    UUID getUuid();
 }

--- a/src/main/java/com/raoulvdberge/refinedstorage/api/autocrafting/ICraftingPatternContainer.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/api/autocrafting/ICraftingPatternContainer.java
@@ -6,7 +6,9 @@ import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
 import javax.annotation.Nullable;
+
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Represents a network node that contains crafting patterns.
@@ -18,9 +20,14 @@ public interface ICraftingPatternContainer {
     int getSpeedUpdateCount();
 
     /**
-     * @return the inventory that this container is facing
+     * @return the inventory that this container is connected to
      */
-    IItemHandler getFacingInventory();
+    IItemHandler getConnectedInventory();
+
+    /**
+     * @return the tile that this container is connected to
+     */
+    TileEntity getConnectedTile();
 
     /**
      * @return the tile that this container is facing
@@ -53,7 +60,17 @@ public interface ICraftingPatternContainer {
     BlockPos getPosition();
 
     /**
-     * @return true if this container is blocked, false otherwise
+     * Containers may be daisy-chained together.  If this container points to
+     * another one, gets the last container in the chain.  Otherwise, this
+     * container is the last in the chain.
+     *
+     * @return the root pattern container
+     */
+    @Nullable
+    ICraftingPatternContainer getProxyPatternContainer();
+
+    /**
+     * @return true if this container or its proxy is blocked, false otherwise
      */
     boolean isBlocked();
 
@@ -61,4 +78,9 @@ public interface ICraftingPatternContainer {
      * @param blocked whether the container should be blocked
      */
     void setBlocked(boolean blocked);
+
+    /**
+     * @param blockedOn the descendant that this container is blocked on
+     */
+    void setBlockedOn(UUID blockedOn);
 }

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/CraftingManager.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/CraftingManager.java
@@ -78,26 +78,31 @@ public class CraftingManager implements ICraftingManager {
 
     @Override
     public void addContainerBlock(UUID blocker, UUID blockee) {
-        if (blockedContainers.contains(blockee) || blockingContainers.containsKey(blocker)) {
-            throw new IllegalStateException();
-        }
         blockedContainers.add(blockee);
         blockingContainers.put(blocker, blockee);
     }
 
     @Override
     public void removeContainerBlock(UUID blocker) {
-        UUID blockee = blockingContainers.get(blocker);
-        if (blockee == null || !blockedContainers.contains(blockee)) {
-            throw new IllegalStateException();
-        }
-        blockedContainers.remove(blockee);
+        blockedContainers.remove(blockingContainers.get(blocker));
         blockingContainers.remove(blocker);
     }
 
     @Override
     public boolean isContainerBlocked(UUID blockee) {
         return blockedContainers.contains(blockee);
+    }
+
+    @Override
+    public void setContainerBlocked(ICraftingPatternContainer container, boolean blocked) {
+        if (blocked) {
+            ICraftingPatternContainer proxy = container.getRootContainer();
+            if (proxy != null) {
+                addContainerBlock(container.getUuid(), proxy.getUuid());
+            }
+        } else {
+            removeContainerBlock(container.getUuid());
+        }
     }
 
     @Override

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/task/CraftingStep.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/task/CraftingStep.java
@@ -122,7 +122,7 @@ public abstract class CraftingStep implements ICraftingStep {
     @Override
     public void setStartedProcessing() {
         if (getPattern().isBlocking()) {
-            getPattern().getContainer().setBlocked(true);
+            getPattern().getContainer().setBlocked(network, true);
         }
 
         startedProcessing = true;
@@ -144,7 +144,7 @@ public abstract class CraftingStep implements ICraftingStep {
         }
 
         if (getPattern().isBlocking()) {
-            getPattern().getContainer().setBlocked(false);
+            getPattern().getContainer().setBlocked(network, false);
         }
 
         return true;

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/task/CraftingStep.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/task/CraftingStep.java
@@ -122,7 +122,7 @@ public abstract class CraftingStep implements ICraftingStep {
     @Override
     public void setStartedProcessing() {
         if (getPattern().isBlocking()) {
-            getPattern().getContainer().setBlocked(network, true);
+            network.getCraftingManager().setContainerBlocked(getPattern().getContainer(), true);
         }
 
         startedProcessing = true;
@@ -144,7 +144,7 @@ public abstract class CraftingStep implements ICraftingStep {
         }
 
         if (getPattern().isBlocking()) {
-            getPattern().getContainer().setBlocked(network, false);
+            network.getCraftingManager().setContainerBlocked(getPattern().getContainer(), false);
         }
 
         return true;

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/task/CraftingStepProcess.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/task/CraftingStepProcess.java
@@ -35,7 +35,7 @@ public class CraftingStepProcess extends CraftingStep {
             return false;
         }
 
-        IItemHandler inventory = getPattern().getContainer().getFacingInventory();
+        IItemHandler inventory = getPattern().getContainer().getConnectedInventory();
 
         int compare = CraftingTask.DEFAULT_COMPARE | (pattern.isOredict() ? IComparer.COMPARE_OREDICT : 0);
 
@@ -80,7 +80,7 @@ public class CraftingStepProcess extends CraftingStep {
             return false;
         }
 
-        IItemHandler inventory = getPattern().getContainer().getFacingInventory();
+        IItemHandler inventory = getPattern().getContainer().getConnectedInventory();
 
         return inventory != null && insertItems(inventory, new LinkedList<>(getInputs()), true);
     }
@@ -92,7 +92,7 @@ public class CraftingStepProcess extends CraftingStep {
         int compare = CraftingTask.DEFAULT_COMPARE | (getPattern().isOredict() ? IComparer.COMPARE_OREDICT : 0);
 
         if (extractItems(extracted, compare, toInsertItems)) {
-            IItemHandler inventory = getPattern().getContainer().getFacingInventory();
+            IItemHandler inventory = getPattern().getContainer().getConnectedInventory();
 
             if (insertItems(inventory, new ArrayDeque<>(extracted), true)) {
                 insertItems(inventory, extracted, false);

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/task/CraftingTask.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/task/CraftingTask.java
@@ -670,7 +670,7 @@ public class CraftingTask implements ICraftingTask {
                             32
                         );
 
-                        if (step.getPattern().getContainer().getFacingTile() == null) {
+                        if (step.getPattern().getContainer().getConnectedTile() == null) {
                             element = new CraftingMonitorElementError(element, "gui.refinedstorage:crafting_monitor.machine_none");
                         } else if (!step.hasStartedProcessing() && !step.canStartProcessing()) {
                             element = new CraftingMonitorElementError(element, "gui.refinedstorage:crafting_monitor.machine_in_use");

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/task/CraftingTask.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/task/CraftingTask.java
@@ -404,7 +404,7 @@ public class CraftingTask implements ICraftingTask {
 
         for (ICraftingStep step : getSteps()) {
             if (step.getPattern().isBlocking()) {
-                step.getPattern().getContainer().setBlocked(false);
+                step.getPattern().getContainer().setBlocked(network, false);
             }
         }
 

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/task/CraftingTask.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/task/CraftingTask.java
@@ -404,7 +404,7 @@ public class CraftingTask implements ICraftingTask {
 
         for (ICraftingStep step : getSteps()) {
             if (step.getPattern().isBlocking()) {
-                step.getPattern().getContainer().setBlocked(network, false);
+                network.getCraftingManager().setContainerBlocked(step.getPattern().getContainer(), false);
             }
         }
 

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/network/node/NetworkNode.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/network/node/NetworkNode.java
@@ -215,7 +215,15 @@ public abstract class NetworkNode implements INetworkNode, INetworkNodeVisitor, 
 
     // @todo: Move this data to the network node.
     public void resetDirection() {
-        this.direction = ((TileBase) (IntegrationMCMP.isLoaded() ? RSMCMPAddon.unwrapTile(world, pos) : world.getTileEntity(pos))).getDirection();
+        EnumFacing direction = ((TileBase) (IntegrationMCMP.isLoaded() ? RSMCMPAddon.unwrapTile(world, pos) : world.getTileEntity(pos))).getDirection();
+        if (!direction.equals(this.direction)) {
+            this.direction = direction;
+            onDirectionChanged();
+        }
+    }
+
+    protected void onDirectionChanged() {
+        // NO OP
     }
 
     @Nullable

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/network/node/NetworkNodeCrafter.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/network/node/NetworkNodeCrafter.java
@@ -26,7 +26,6 @@ import net.minecraftforge.items.wrapper.CombinedInvWrapper;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 
 public class NetworkNodeCrafter extends NetworkNode implements ICraftingPatternContainer {

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/network/node/NetworkNodeCrafter.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/network/node/NetworkNodeCrafter.java
@@ -101,24 +101,6 @@ public class NetworkNodeCrafter extends NetworkNode implements ICraftingPatternC
         }
     }
 
-    private void setBlockedInternal(INetwork network, boolean blocked) {
-        Set<UUID> blockingContainers = network.getCraftingManager().getBlockingContainers();
-        if (uuid == null) {
-            uuid = UUID.randomUUID();
-            markDirty();
-        }
-        if (blocked) {
-            blockingContainers.add(uuid);
-
-            ICraftingPatternContainer proxy = getProxyPatternContainer();
-            if (proxy != null) {
-                proxy.setBlockedOn(uuid);
-            }
-        } else {
-            blockingContainers.remove(uuid);
-        }
-    }
-
     @Override
     public int getEnergyUsage() {
         return RS.INSTANCE.config.crafterUsage + upgrades.getEnergyUsage() + (RS.INSTANCE.config.crafterPerPatternUsage * actualPatterns.size());
@@ -141,7 +123,7 @@ public class NetworkNodeCrafter extends NetworkNode implements ICraftingPatternC
             network.getCraftingManager().getTasks().stream()
                 .filter(task -> task.getPattern().getContainer().getPosition().equals(pos))
                 .forEach(task -> network.getCraftingManager().cancel(task));
-            setBlockedInternal(network, false);
+            setBlocked(network, false);
         }
 
         network.getCraftingManager().rebuild();
@@ -311,8 +293,22 @@ public class NetworkNodeCrafter extends NetworkNode implements ICraftingPatternC
     }
 
     @Override
-    public void setBlocked(boolean blocked) {
-        setBlockedInternal(network, blocked);
+    public void setBlocked(INetwork network, boolean blocked) {
+        Set<UUID> blockingContainers = network.getCraftingManager().getBlockingContainers();
+        if (uuid == null) {
+            uuid = UUID.randomUUID();
+            markDirty();
+        }
+        if (blocked) {
+            blockingContainers.add(uuid);
+
+            ICraftingPatternContainer proxy = getProxyPatternContainer();
+            if (proxy != null) {
+                proxy.setBlockedOn(uuid);
+            }
+        } else {
+            blockingContainers.remove(uuid);
+        }
     }
 
     @Override

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/network/node/NetworkNodeCrafter.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/network/node/NetworkNodeCrafter.java
@@ -64,7 +64,7 @@ public class NetworkNodeCrafter extends NetworkNode implements ICraftingPatternC
 
     private ItemHandlerUpgrade upgrades = new ItemHandlerUpgrade(4, new ItemHandlerListenerNetworkNode(this), ItemUpgrade.TYPE_SPEED);
 
-    // Used to prevent infinite recursion on getProxyPatternContainer() when
+    // Used to prevent infinite recursion on getRootContainer() when
     // there's eg. two crafters facing each other.
     private boolean visited = false;
 
@@ -116,7 +116,7 @@ public class NetworkNodeCrafter extends NetworkNode implements ICraftingPatternC
             network.getCraftingManager().getTasks().stream()
                 .filter(task -> task.getPattern().getContainer().getPosition().equals(pos))
                 .forEach(task -> network.getCraftingManager().cancel(task));
-            setBlocked(network, false);
+            network.getCraftingManager().setContainerBlocked(this, false);
         }
 
         network.getCraftingManager().rebuild();
@@ -175,7 +175,7 @@ public class NetworkNodeCrafter extends NetworkNode implements ICraftingPatternC
 
     @Override
     public IItemHandler getConnectedInventory() {
-        ICraftingPatternContainer proxy = getProxyPatternContainer();
+        ICraftingPatternContainer proxy = getRootContainer();
         if (proxy == null) {
             return null;
         }
@@ -184,7 +184,7 @@ public class NetworkNodeCrafter extends NetworkNode implements ICraftingPatternC
 
     @Override
     public TileEntity getConnectedTile() {
-        ICraftingPatternContainer proxy = getProxyPatternContainer();
+        ICraftingPatternContainer proxy = getRootContainer();
         if (proxy == null) {
             return null;
         }
@@ -255,7 +255,7 @@ public class NetworkNodeCrafter extends NetworkNode implements ICraftingPatternC
 
     @Override
     @Nullable
-    public ICraftingPatternContainer getProxyPatternContainer() {
+    public ICraftingPatternContainer getRootContainer() {
         if (visited) {
             return null;
         }
@@ -266,27 +266,15 @@ public class NetworkNodeCrafter extends NetworkNode implements ICraftingPatternC
         }
 
         visited = true;
-        ICraftingPatternContainer facingContainer = ((ICraftingPatternContainer)facing).getProxyPatternContainer();
+        ICraftingPatternContainer facingContainer = ((ICraftingPatternContainer)facing).getRootContainer();
         visited = false;
         return facingContainer;
     }
 
     @Override
     public boolean isBlocked() {
-        ICraftingPatternContainer proxy = getProxyPatternContainer();
+        ICraftingPatternContainer proxy = getRootContainer();
         return proxy != null && network != null && network.getCraftingManager().isContainerBlocked(proxy.getUuid());
-    }
-
-    @Override
-    public void setBlocked(INetwork network, boolean blocked) {
-        if (blocked) {
-            ICraftingPatternContainer proxy = getProxyPatternContainer();
-            if (proxy != null) {
-                network.getCraftingManager().addContainerBlock(getUuid(), proxy.getUuid());
-            }
-        } else {
-            network.getCraftingManager().removeContainerBlock(getUuid());
-        }
     }
 
     @Override


### PR DESCRIPTION
In crafting situations that require more than the 9 blocking patterns
that one crafter allows, the only solution is to duplicate the setup
to allow a second crafter.  This CL allows crafters to be
daisy-chained to provide a solution to this issue.

Also, since unlimited crafters can now be placed on a single
inventory, this eliminates the need to have multiple intermediate
inventories which then pipe into the desired inventory.  This also
improves the crafting manager UI as now those patterns can all be
listed under one "Furnace" instead of (potentially multiple) "Chest"s.