### PR TITLE
Fix repeated key events not getting handled in search boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added OR search operator to the Grid with "|" (raoulvdberge)
 - getPatterns() now only returns all the outputs, this to limit memory usage in OpenComputers (only affects OC integration). (fspijkerman)
 - Added new getPattern(stack:table) function for OpenComputers integration (fspijkerman)
+- Fixed repeated key events not getting handled in some cases (tomKPZ)
 
 ### 1.5.33
 - Added Crafter Manager (raoulvdberge)

--- a/src/main/java/com/raoulvdberge/refinedstorage/gui/GuiBase.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/gui/GuiBase.java
@@ -20,6 +20,8 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.client.config.GuiCheckBox;
 import net.minecraftforge.fml.client.config.GuiUtils;
 import net.minecraftforge.items.SlotItemHandler;
+
+import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 
 import javax.annotation.Nonnull;
@@ -101,6 +103,8 @@ public abstract class GuiBase extends GuiContainer {
 
         initializing = true;
 
+        Keyboard.enableRepeatEvents(true);
+
         calcHeight();
 
         super.initGui();
@@ -115,6 +119,12 @@ public abstract class GuiBase extends GuiContainer {
         runRunnables();
 
         initializing = false;
+    }
+
+    @Override
+    public void onGuiClosed() {
+        super.onGuiClosed();
+        Keyboard.enableRepeatEvents(false);
     }
 
     protected void calcHeight() {


### PR DESCRIPTION
GUIs are supposed to call enableRepeatEvents() from initGui() and
onGuiClosed() to properly handle repeated key events.  This change
adds the appropriate calls in GuiBase.

See the equivalent code in eg. Applied Energistics 2:
https://github.com/AppliedEnergistics/Applied-Energistics-2/blob/cc9b33b47335ddb7be29a007de3f7e364fdc1859/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java#L224
https://github.com/AppliedEnergistics/Applied-Energistics-2/blob/cc9b33b47335ddb7be29a007de3f7e364fdc1859/src/main/java/appeng/client/gui/implementations/GuiMEMonitorable.java#L399

Fixes https://github.com/raoulvdberge/refinedstorage/issues/1762