### PR TITLE
fix: set count for matched oredict results

### DIFF
--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/CraftingPattern.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/CraftingPattern.java
@@ -70,6 +70,11 @@ public class CraftingPattern implements ICraftingPattern {
                         }
                     }
 
+                    // Fix item count
+                    for (ItemStack ore: ores) {
+                        ore.setCount(input.getCount());
+                    }
+
                     inputs.add(ores);
                 } else {
                     inputs.add(NonNullList.from(ItemStack.EMPTY, input));


### PR DESCRIPTION
Currently when an oredict processing pattern matched a different input that wasn't in the original pattern, (say a copper ignot from IC² instead of Thermal Expansion) it doesn't set the count, and it will try to use only 1, as seen in the screenshots

![pattern](https://user-images.githubusercontent.com/1922630/50649406-18548900-0f7e-11e9-8bfe-a888069854dd.png)
![now_oredict](https://user-images.githubusercontent.com/1922630/50649403-18548900-0f7e-11e9-8059-7c8f753e0766.png)
![wat_is_this](https://user-images.githubusercontent.com/1922630/50649402-17bbf280-0f7e-11e9-82a9-42ce009f83e8.png)

With this fix:

![i_did_that](https://user-images.githubusercontent.com/1922630/50649401-17bbf280-0f7e-11e9-9103-d5985d72863c.png)
