### PR TITLE
catch payload too large for #1790

### DIFF
--- a/src/main/java/com/raoulvdberge/refinedstorage/integration/jei/RecipeTransferHandlerGrid.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/integration/jei/RecipeTransferHandlerGrid.java
@@ -84,7 +84,12 @@ public class RecipeTransferHandlerGrid implements IRecipeTransferHandler {
 
                 RS.INSTANCE.network.sendToServer(new MessageGridProcessingTransfer(inputs, outputs, fluidInputs, fluidOutputs));
             } else {
-                RS.INSTANCE.network.sendToServer(new MessageGridTransfer(recipeLayout.getItemStacks().getGuiIngredients(), container.inventorySlots.stream().filter(s -> s.inventory instanceof InventoryCrafting).collect(Collectors.toList())));
+                try {
+                    RS.INSTANCE.network.sendToServer(new MessageGridTransfer(recipeLayout.getItemStacks().getGuiIngredients(), container.inventorySlots.stream().filter(s -> s.inventory instanceof InventoryCrafting).collect(Collectors.toList())));
+                } catch (IllegalArgumentException e){
+                    //TODO: React to Payload error
+                }
+
             }
         } else {
             if (grid.getGridType() == GridType.PATTERN && ((NetworkNodeGrid) grid).isProcessingPattern()) {


### PR DESCRIPTION
So from what I've gathered we ideally would want JEI to tell us the Registry name of the recipe so that could be sent instead. I can't find that though so until then just not making it crash is at least something we can do.

As for what to actually do after catching the error. I could:

1. Recursively split the package in half and send multiple.
2. Render something by adding a new value into the container and reading that from the GUI.
3. return a JEITransferError. The convenient User facing errors don't work at that point anymore though. But this makes clicking the button do nothing.
4. Just keep what it does now which makes it look like it worked but doesn't actually do anything.

Kinda hoping there is a much cleaner solution somewhere so if anyone has any suggestions.... 