### PR TITLE
restrict gregtech rendering ban to wires and machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Shortened crafting text for the Russion translation to fix Grid overlays (yaroslav4167)
 - Fixed JEI hotkeys not working on fluid filter slots (raoulvdberge)
 - Fixed crash when opening Crafter Manager with FTB Quests installed (raoulvdberge)
-- GregTech Community Edition items are now banned from rendering on Refined Storage patterns because they are causing crashes (raoulvdberge)
+- GregTech Community Edition Wires and Machines are now banned from rendering on Refined Storage patterns because they are causing crashes (raoulvdberge/Darkere)
 
 ### 1.6.14
 - Fixed server crash (raoulvdberge)

--- a/src/main/java/com/raoulvdberge/refinedstorage/render/model/baked/BakedModelPattern.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/render/model/baked/BakedModelPattern.java
@@ -40,8 +40,7 @@ public class BakedModelPattern extends BakedModelDelegate {
                     ItemStack outputToRender = pattern.getOutputs().get(0);
 
                     // @Volatile: Gregtech banned for rendering due to issues
-                    if (!("gregtech".equals(outputToRender.getItem().getCreatorModId(outputToRender))
-                            && (outputToRender.getTranslationKey().equals("tile.pipe")||outputToRender.getItem().delegate.name().getPath().equals("machine")))) {
+                    if (!hasBrokenRendering(outputToRender)) {
                         return Minecraft.getMinecraft().getRenderItem().getItemModelWithOverrides(outputToRender, world, entity);
                     }
                 }
@@ -49,6 +48,19 @@ public class BakedModelPattern extends BakedModelDelegate {
                 return super.handleItemState(originalModel, stack, world, entity);
             }
         };
+    }
+
+    private boolean hasBrokenRendering(ItemStack stack) {
+        if ("gregtech".equals(stack.getItem().getCreatorModId(stack))) {
+            if ("tile.pipe".equals(stack.getTranslationKey())) {
+                return true;
+            }
+
+            if ("machine".equals(stack.getItem().delegate.name().getPath())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static boolean canDisplayOutput(ItemStack patternStack, CraftingPattern pattern) {

--- a/src/main/java/com/raoulvdberge/refinedstorage/render/model/baked/BakedModelPattern.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/render/model/baked/BakedModelPattern.java
@@ -40,7 +40,8 @@ public class BakedModelPattern extends BakedModelDelegate {
                     ItemStack outputToRender = pattern.getOutputs().get(0);
 
                     // @Volatile: Gregtech banned for rendering due to issues
-                    if (!"gregtech".equals(outputToRender.getItem().getCreatorModId(outputToRender))) {
+                    if (!("gregtech".equals(outputToRender.getItem().getCreatorModId(outputToRender))
+                            && (outputToRender.getTranslationKey().equals("tile.pipe")||outputToRender.getItem().delegate.name().getPath().equals("machine")))) {
                         return Minecraft.getMinecraft().getRenderItem().getItemModelWithOverrides(outputToRender, world, entity);
                     }
                 }


### PR DESCRIPTION
They are using some weird stuff for their Itemregistration. 
Translationkey is "unnamed". That's why over resource location. 

Machines don't actually crash they just render nothing so that part is not strictly required. 