### PR TITLE
Fixed broken rendering of patterns

### DIFF
--- a/src/main/java/com/raoulvdberge/refinedstorage/render/model/baked/BakedModelPattern.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/render/model/baked/BakedModelPattern.java
@@ -39,28 +39,12 @@ public class BakedModelPattern extends BakedModelDelegate {
                 if (canDisplayOutput(stack, pattern)) {
                     ItemStack outputToRender = pattern.getOutputs().get(0);
 
-                    // @Volatile: Gregtech banned for rendering due to issues
-                    if (!hasBrokenRendering(outputToRender)) {
-                        return Minecraft.getMinecraft().getRenderItem().getItemModelWithOverrides(outputToRender, world, entity);
-                    }
+                    return new BakedModelDelegate(Minecraft.getMinecraft().getRenderItem().getItemModelWithOverrides(outputToRender, world, entity));
                 }
 
                 return super.handleItemState(originalModel, stack, world, entity);
             }
         };
-    }
-
-    private boolean hasBrokenRendering(ItemStack stack) {
-        if ("gregtech".equals(stack.getItem().getCreatorModId(stack))) {
-            if ("tile.pipe".equals(stack.getTranslationKey())) {
-                return true;
-            }
-
-            if ("machine".equals(stack.getItem().delegate.name().getPath())) {
-                return true;
-            }
-        }
-        return false;
     }
 
     public static boolean canDisplayOutput(ItemStack patternStack, CraftingPattern pattern) {

--- a/src/main/java/com/raoulvdberge/refinedstorage/render/teisr/TileEntityItemStackRendererPattern.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/render/teisr/TileEntityItemStackRendererPattern.java
@@ -2,23 +2,53 @@ package com.raoulvdberge.refinedstorage.render.teisr;
 
 import com.raoulvdberge.refinedstorage.apiimpl.autocrafting.CraftingPattern;
 import com.raoulvdberge.refinedstorage.item.ItemPattern;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.RenderItem;
+import net.minecraft.client.renderer.block.model.IBakedModel;
 import net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer;
 import net.minecraft.item.ItemStack;
 
 public class TileEntityItemStackRendererPattern extends TileEntityItemStackRenderer {
     @Override
     public void renderByItem(ItemStack stack) {
-        CraftingPattern pattern = ItemPattern.getPatternFromCache(null, stack);
-        ItemStack outputStack = pattern.getOutputs().get(0);
-
-        outputStack.getItem().getTileEntityItemStackRenderer().renderByItem(outputStack);
+    	renderByItem(stack, 1.0F);
     }
 
-    @Override
+	@Override
     public void renderByItem(ItemStack stack, float partialTicks) {
         CraftingPattern pattern = ItemPattern.getPatternFromCache(null, stack);
         ItemStack outputStack = pattern.getOutputs().get(0);
 
-        outputStack.getItem().getTileEntityItemStackRenderer().renderByItem(outputStack, partialTicks);
+		GlStateManager.pushMatrix();
+		if(handleBrokenRendering(outputStack)) {
+	        RenderItem renderer = Minecraft.getMinecraft().getRenderItem();
+	        IBakedModel model = renderer.getItemModelWithOverrides(outputStack, null, null);
+	        
+			renderer.renderItem(outputStack, model);
+		}else {
+			outputStack.getItem().getTileEntityItemStackRenderer().renderByItem(outputStack, partialTicks);
+		}
+		GlStateManager.popMatrix();
+    }
+	
+	private boolean handleBrokenRendering(ItemStack stack) {
+		String creatorModId = stack.getItem().getCreatorModId(stack);
+		if(creatorModId == null) return false;
+		
+		switch(creatorModId) {
+			case "gregtech":
+			case "gtadditions":
+				 if ("tile.pipe".equals(stack.getTranslationKey()) || "machine".equals(stack.getItem().delegate.name().getPath())) {
+		            	GlStateManager.translate(0.5, 0.5, 0.5);
+		                return true;
+		            }
+				break;
+				
+			default:
+				break;
+		}
+        return false;
     }
 }


### PR DESCRIPTION
Pattern rendering now goes through TileEntityItemStackRendererPattern as intended, but some GregTech stacks are still being handled differently. At least everything renders properly...