### PR TITLE
Various JEI fixes

### DIFF
--- a/src/main/java/com/raoulvdberge/refinedstorage/gui/grid/view/GridViewBase.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/gui/grid/view/GridViewBase.java
@@ -32,6 +32,11 @@ public abstract class GridViewBase implements IGridView {
     }
 
     @Override
+    public Collection<IGridStack> getAllStacks() {
+        return map.values();
+    }
+
+    @Override
     public void sort() {
         List<IGridStack> stacks = new ArrayList<>();
 

--- a/src/main/java/com/raoulvdberge/refinedstorage/gui/grid/view/IGridView.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/gui/grid/view/IGridView.java
@@ -2,10 +2,13 @@ package com.raoulvdberge.refinedstorage.gui.grid.view;
 
 import com.raoulvdberge.refinedstorage.gui.grid.stack.IGridStack;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface IGridView {
     List<IGridStack> getStacks();
+
+    Collection<IGridStack> getAllStacks();
 
     void setStacks(List<IGridStack> stacks);
 

--- a/src/main/java/com/raoulvdberge/refinedstorage/integration/jei/RSJEIPlugin.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/integration/jei/RSJEIPlugin.java
@@ -15,7 +15,7 @@ public class RSJEIPlugin implements IModPlugin {
     public void register(IModRegistry registry) {
         INSTANCE = this;
 
-        registry.getRecipeTransferRegistry().addUniversalRecipeTransferHandler(new RecipeTransferHandlerGrid());
+        registry.getRecipeTransferRegistry().addUniversalRecipeTransferHandler(new RecipeTransferHandlerGrid(registry.getJeiHelpers().recipeTransferHandlerHelper()));
 
         registry.addAdvancedGuiHandlers(new AdvancedGuiHandler());
 

--- a/src/main/java/com/raoulvdberge/refinedstorage/integration/jei/RecipeRegistryPluginCover.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/integration/jei/RecipeRegistryPluginCover.java
@@ -33,7 +33,7 @@ public class RecipeRegistryPluginCover implements IRecipeRegistryPlugin {
 
     @Override
     public <T extends IRecipeWrapper, V> List<T> getRecipeWrappers(IRecipeCategory<T> recipeCategory, IFocus<V> focus) {
-        if (focus.getValue() instanceof ItemStack) {
+        if (focus.getValue() instanceof ItemStack && recipeCategory.getUid().equals(VanillaRecipeCategoryUid.CRAFTING)) {
             ItemStack stack = (ItemStack) focus.getValue();
 
             if (focus.getMode() == IFocus.Mode.INPUT) {

--- a/src/main/java/com/raoulvdberge/refinedstorage/integration/jei/RecipeRegistryPluginHollowCover.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/integration/jei/RecipeRegistryPluginHollowCover.java
@@ -38,7 +38,7 @@ public class RecipeRegistryPluginHollowCover implements IRecipeRegistryPlugin {
 
     @Override
     public <T extends IRecipeWrapper, V> List<T> getRecipeWrappers(IRecipeCategory<T> recipeCategory, IFocus<V> focus) {
-        if (focus.getValue() instanceof ItemStack) {
+        if (focus.getValue() instanceof ItemStack && recipeCategory.getUid().equals(VanillaRecipeCategoryUid.CRAFTING)) {
             ItemStack stack = (ItemStack) focus.getValue();
 
             if (focus.getMode() == IFocus.Mode.INPUT) {

--- a/src/main/java/com/raoulvdberge/refinedstorage/integration/jei/RecipeTransferErrorAutocraftSlots.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/integration/jei/RecipeTransferErrorAutocraftSlots.java
@@ -1,0 +1,56 @@
+package com.raoulvdberge.refinedstorage.integration.jei;
+
+import mezz.jei.api.gui.IGuiIngredient;
+import mezz.jei.api.gui.IGuiItemStackGroup;
+import mezz.jei.api.gui.IRecipeLayout;
+import mezz.jei.api.recipe.transfer.IRecipeTransferError;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraftforge.fml.client.config.GuiUtils;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class RecipeTransferErrorAutocraftSlots implements IRecipeTransferError {
+    private static final Color HIGHLIGHT_COLOR = new Color(1.0f, 0.0f, 0.0f, 0.4f);
+    private static final Color HIGHLIGHT_AUTOCRAFT_COLOR = new Color(0.0f, 0.0f, 1.0f, 0.4f);
+    private final Collection<Integer> slots;
+    private final Collection<Integer> autocraftSlots;
+    private final List<String> message = new ArrayList<>();
+
+    public RecipeTransferErrorAutocraftSlots(String message, String autocraftMessage, Collection<Integer> slots, Collection<Integer> autocraftSlots) {
+        this.message.add(I18n.format("jei.tooltip.transfer"));
+        this.message.add(TextFormatting.RED + message);
+        this.message.add(TextFormatting.BLUE + autocraftMessage);
+
+        this.slots = slots;
+        this.autocraftSlots = autocraftSlots;
+    }
+
+    @Override
+    public Type getType() {
+        return Type.USER_FACING;
+    }
+
+    @Override
+    public void showError(Minecraft minecraft, int mouseX, int mouseY, IRecipeLayout recipeLayout, int recipeX, int recipeY) {
+        IGuiItemStackGroup itemStackGroup = recipeLayout.getItemStacks();
+        Map<Integer, ? extends IGuiIngredient<ItemStack>> ingredients = itemStackGroup.getGuiIngredients();
+        for (Integer slotIndex : slots) {
+            IGuiIngredient<ItemStack> ingredient = ingredients.get(slotIndex);
+            ingredient.drawHighlight(minecraft, HIGHLIGHT_COLOR, recipeX, recipeY);
+        }
+        for (Integer slotIndex : autocraftSlots) {
+            IGuiIngredient<ItemStack> ingredient = ingredients.get(slotIndex);
+            ingredient.drawHighlight(minecraft, HIGHLIGHT_AUTOCRAFT_COLOR, recipeX, recipeY);
+        }
+        ScaledResolution scaledresolution = new ScaledResolution(minecraft);
+        GuiUtils.drawHoveringText(ItemStack.EMPTY, message, mouseX, mouseY, scaledresolution.getScaledWidth(), scaledresolution.getScaledHeight(), 150, minecraft.fontRenderer);
+    }
+}

--- a/src/main/java/com/raoulvdberge/refinedstorage/integration/jei/RecipeTransferHandlerGrid.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/integration/jei/RecipeTransferHandlerGrid.java
@@ -3,10 +3,16 @@ package com.raoulvdberge.refinedstorage.integration.jei;
 import com.raoulvdberge.refinedstorage.RS;
 import com.raoulvdberge.refinedstorage.api.network.grid.GridType;
 import com.raoulvdberge.refinedstorage.api.network.grid.IGrid;
+import com.raoulvdberge.refinedstorage.api.util.IComparer;
+import com.raoulvdberge.refinedstorage.apiimpl.API;
 import com.raoulvdberge.refinedstorage.apiimpl.network.node.NetworkNodeGrid;
 import com.raoulvdberge.refinedstorage.container.ContainerGrid;
+import com.raoulvdberge.refinedstorage.gui.grid.GuiGrid;
+import com.raoulvdberge.refinedstorage.gui.grid.stack.GridStackItem;
+import com.raoulvdberge.refinedstorage.gui.grid.stack.IGridStack;
 import com.raoulvdberge.refinedstorage.network.MessageGridProcessingTransfer;
 import com.raoulvdberge.refinedstorage.network.MessageGridTransfer;
+import mezz.jei.api.IRecipesGui;
 import mezz.jei.api.gui.IGuiIngredient;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
@@ -17,11 +23,12 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
-import java.util.LinkedList;
-import java.util.List;
+import java.lang.reflect.InvocationTargetException;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class RecipeTransferHandlerGrid implements IRecipeTransferHandler<ContainerGrid> {
@@ -73,6 +80,139 @@ public class RecipeTransferHandlerGrid implements IRecipeTransferHandler<Contain
         } else { // gridType == GridType.CRAFTING
             if (!isCraftingRecipe) {
                 return ERROR_CANNOT_TRANSFER;
+            }
+
+            // Check whether we have enough items to craft the recipe and return an error if we don't.
+            // To get the items grid, we get the grid's GUI from an internal JEI method and use its GridView.
+            // There is no other (synchronous) way of retrieving a list of items in the grid.
+
+            // This should try to replicate the behaviour of NetworkNodeGrid#onRecipeTransfer.
+            // Assume there is enough space in the network to clear the crafting matrix - there's no way of determining
+            // this without access to the network itself.
+            IRecipesGui recipesGui = RSJEIPlugin.INSTANCE.getRuntime().getRecipesGui();
+            try {
+                Object parentScreen = recipesGui.getClass().getMethod("getParentScreen").invoke(recipesGui);
+                if (parentScreen instanceof GuiGrid) {
+                    // Using IGridView#getStacks will return a *filtered* list of items in the view,
+                    // which will cause problems - especially if the user uses JEI synchronised searching.
+                    // Instead, we will use IGridView#getAllStacks which provides an unordered view of all GridStacks.
+                    Collection<IGridStack> gridStacks = ((GuiGrid) parentScreen).getView().getAllStacks();
+
+                    boolean[] isFound = new boolean[9];
+                    boolean[] canAutocraft = new boolean[9];
+                    // Map from Items to a 9-long array of slots, where each slot is an array of ItemStacks which is
+                    // valid in that slot of the recipe.
+                    Map<Item, List<List<ItemStack>>> ingredientsToSlotsToStacks = new HashMap<>();
+
+                    Map<Integer, ? extends IGuiIngredient<ItemStack>> guiIngredients = recipeLayout.getItemStacks().getGuiIngredients();
+
+                    // Initialise variables
+                    for (int i = 0; i < 9; i++) {
+                        isFound[i] = true;
+                        List<ItemStack> ingredients = guiIngredients.get(i + 1).getAllIngredients();
+                        for (ItemStack ingredient : ingredients) {
+                            if (ingredient == null) {
+                                continue;
+                            }
+                            isFound[i] = false;
+                            Item item = ingredient.getItem();
+                            if (!ingredientsToSlotsToStacks.containsKey(item)) {
+                                List<List<ItemStack>> slots = new ArrayList<>(9);
+                                for (int j = 0; j < 9; j++) {
+                                    slots.add(new ArrayList<>());
+                                }
+                                ingredientsToSlotsToStacks.put(item, slots);
+                            }
+                            ingredientsToSlotsToStacks.get(item).get(i).add(ingredient);
+                        }
+                    }
+
+                    // Check grid
+                    IComparer comparer = API.instance().getComparer();
+
+                    for (IGridStack gridStack : gridStacks) {
+                        if (!(gridStack instanceof GridStackItem)) {
+                            continue;
+                        }
+                        if (!ingredientsToSlotsToStacks.containsKey(((GridStackItem) gridStack).getStack().getItem())) {
+                            continue;
+                        }
+                        GridStackItem gridStackItem = (GridStackItem) gridStack;
+                        ItemStack stack = gridStackItem.getStack();
+                        Item item = stack.getItem();
+                        List<List<ItemStack>> slots = ingredientsToSlotsToStacks.get(item);
+
+                        int available = gridStackItem.getQuantity();
+                        int compareDamage = item.isDamageable() ? 0 : IComparer.COMPARE_DAMAGE;
+                        for (int i = 0; i < 9; i++) {
+                            if (isFound[i]) {
+                                continue;
+                            }
+                            for (ItemStack possibility : slots.get(i)) {
+                                if (comparer.isEqual(possibility, stack, IComparer.COMPARE_NBT | compareDamage)) {
+                                    if (possibility.getCount() <= available) {
+                                        isFound[i] = true;
+                                        available -= possibility.getCount();
+                                        break;
+                                    } else if (gridStackItem.isCraftable()) {
+                                        canAutocraft[i] = true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // Check inventory
+                    for (int inventorySlot = 0; inventorySlot < player.inventory.getSizeInventory(); inventorySlot++) {
+                        if (!ingredientsToSlotsToStacks.containsKey(player.inventory.getStackInSlot(inventorySlot).getItem())) {
+                            continue;
+                        }
+                        ItemStack stack = player.inventory.getStackInSlot(inventorySlot);
+                        Item item = stack.getItem();
+                        List<List<ItemStack>> slots = ingredientsToSlotsToStacks.get(item);
+
+                        int available = stack.getCount();
+                        int compareDamage = item.isDamageable() ? 0 : IComparer.COMPARE_DAMAGE;
+                        for (int i = 0; i < 9; i++) {
+                            if (isFound[i]) {
+                                continue;
+                            }
+                            for (ItemStack possibility : slots.get(i)) {
+                                if (comparer.isEqual(possibility, stack, IComparer.COMPARE_NBT | compareDamage)) {
+                                    if (possibility.getCount() <= available) {
+                                        isFound[i] = true;
+                                        available -= possibility.getCount();
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // Generate an appropriate error if necessary
+                    List<Integer> missingItems = new ArrayList<>();
+                    List<Integer> missingAutocraftItems = new ArrayList<>();
+                    for (int i = 0; i < 9; i++) {
+                        if (!isFound[i]) {
+                            if (canAutocraft[i]) {
+                                missingAutocraftItems.add(i+1);
+                            } else {
+                                missingItems.add(i+1);
+                            }
+                        }
+                    }
+                    if (!missingAutocraftItems.isEmpty()) {
+                        return new RecipeTransferErrorAutocraftSlots(
+                                I18n.format("jei.tooltip.error.recipe.transfer.missing"),
+                                I18n.format("gui.refinedstorage:jei.tooltip.error.recipe.transfer.missing.autocraft"),
+                                missingItems,
+                                missingAutocraftItems);
+                    } else if (!missingItems.isEmpty()) {
+                        return this.handlerHelper.createUserErrorForSlots(I18n.format("jei.tooltip.error.recipe.transfer.missing"), missingItems);
+                    }
+                }
+            } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+                e.printStackTrace();
             }
         }
 

--- a/src/main/java/com/raoulvdberge/refinedstorage/integration/jei/RecipeTransferHandlerGrid.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/integration/jei/RecipeTransferHandlerGrid.java
@@ -162,6 +162,37 @@ public class RecipeTransferHandlerGrid implements IRecipeTransferHandler<Contain
                         }
                     }
 
+                    // Check grid crafting slots
+                    InventoryCrafting craftingMatrix = grid.getCraftingMatrix();
+                    if (craftingMatrix != null) {
+                        for (int matrixSlot = 0; matrixSlot < craftingMatrix.getSizeInventory(); matrixSlot++) {
+                            if (!ingredientsToSlotsToStacks.containsKey(craftingMatrix.getStackInSlot(matrixSlot).getItem())) {
+                                continue;
+                            }
+                            ItemStack stack = craftingMatrix.getStackInSlot(matrixSlot);
+
+                            Item item = stack.getItem();
+                            List<List<ItemStack>> slots = ingredientsToSlotsToStacks.get(item);
+
+                            int available = stack.getCount();
+                            int compareDamage = item.isDamageable() ? 0 : IComparer.COMPARE_DAMAGE;
+                            for (int i = 0; i < 9; i++) {
+                                if (isFound[i]) {
+                                    continue;
+                                }
+                                for (ItemStack possibility : slots.get(i)) {
+                                    if (comparer.isEqual(possibility, stack, IComparer.COMPARE_NBT | compareDamage)) {
+                                        if (possibility.getCount() <= available) {
+                                            isFound[i] = true;
+                                            available -= possibility.getCount();
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
                     // Check inventory
                     for (int inventorySlot = 0; inventorySlot < player.inventory.getSizeInventory(); inventorySlot++) {
                         if (!ingredientsToSlotsToStacks.containsKey(player.inventory.getStackInSlot(inventorySlot).getItem())) {

--- a/src/main/resources/assets/refinedstorage/lang/en_us.lang
+++ b/src/main/resources/assets/refinedstorage/lang/en_us.lang
@@ -88,6 +88,7 @@ gui.refinedstorage:portable_grid=Portable Grid
 gui.refinedstorage:crafter_manager=Crafter Manager
 gui.refinedstorage:jei.tooltip.error.recipe.transfer.pattern.turn_off_processing=Turn off Processing to create this pattern
 gui.refinedstorage:jei.tooltip.error.recipe.transfer.pattern.turn_on_processing=Turn on Processing to create this pattern
+gui.refinedstorage:jei.tooltip.error.recipe.transfer.missing.autocraft=Items can be autocrafted
 
 misc.refinedstorage:energy_stored=%d / %d FE
 misc.refinedstorage:energy_usage=Usage: %d FE/t

--- a/src/main/resources/assets/refinedstorage/lang/en_us.lang
+++ b/src/main/resources/assets/refinedstorage/lang/en_us.lang
@@ -86,6 +86,8 @@ gui.refinedstorage:security_manager.permission.5.tooltip=Ability to change secur
 gui.refinedstorage:storage_monitor=Storage Monitor
 gui.refinedstorage:portable_grid=Portable Grid
 gui.refinedstorage:crafter_manager=Crafter Manager
+gui.refinedstorage:jei.tooltip.error.recipe.transfer.pattern.turn_off_processing=Turn off Processing to create this pattern
+gui.refinedstorage:jei.tooltip.error.recipe.transfer.pattern.turn_on_processing=Turn on Processing to create this pattern
 
 misc.refinedstorage:energy_stored=%d / %d FE
 misc.refinedstorage:energy_usage=Usage: %d FE/t


### PR DESCRIPTION
Most notably, fixes #2237 and fixes #1048 by checking for ingredient availability in JEI's recipe transfer, and displaying a nice user-facing error message. This was highly non-trivial to fix, as JEI's recipe transfer handlers need to be synchronous - so it's impossible to query the RS network in it. Instead, we use an internal JEI function to get the RS grid GUI, and use its GridView to get a list of items. Perhaps we should ask the JEI authors to expose `IRecipesGui#getParentScreen` through the API?

This PR also add a few localized strings, and targets the `mc1.12` branch. The changes should be pretty easy to port over to the existing `mc1.14` branch, as not much JEI integration code has been changed.