### PR TITLE
Add support for item movement via scrolling in grids

### DIFF
--- a/src/main/java/com/raoulvdberge/refinedstorage/api/network/grid/handler/IItemGridHandler.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/api/network/grid/handler/IItemGridHandler.java
@@ -16,23 +16,35 @@ public interface IItemGridHandler {
     int EXTRACT_SHIFT = 4;
 
     /**
+     * Called when a player tries to extract an item from the grid through the Inventory
+     *
+     * @param player        the player that is attempting the extraction
+     * @param stack         the stack we're trying to extract
+     * @param preferredSlot playerInventory slot to prefer when adding or -1
+     * @param flags         how we are extracting, see the flags in {@link IItemGridHandler}
+     */
+    void onExtract(ServerPlayerEntity player, ItemStack stack, int preferredSlot, int flags);
+
+    /**
      * Called when a player tries to extract an item from the grid.
      *
-     * @param player the player that is attempting the extraction
-     * @param id     the id of the item we're trying to extract, this id is the id from {@link com.raoulvdberge.refinedstorage.api.util.StackListEntry}
-     * @param flags  how we are extracting, see the flags in {@link IItemGridHandler}
+     * @param player        the player that is attempting the extraction
+     * @param id            the id of the item we're trying to extract, this id is the id from {@link com.raoulvdberge.refinedstorage.api.util.StackListEntry}
+     * @param preferredSlot playerInventory slot to prefer when adding or -1
+     * @param flags         how we are extracting, see the flags in {@link IItemGridHandler}
      */
-    void onExtract(ServerPlayerEntity player, UUID id, int flags);
+    void onExtract(ServerPlayerEntity player, UUID id, int preferredSlot, int flags);
 
     /**
      * Called when a player tries to insert an item in the grid.
      *
      * @param player the player that is attempting the insert
      * @param stack  the item we're trying to insert
+     * @param single true if we are only inserting a single item, false otherwise
      * @return the remainder, or an empty stack if there is no remainder
      */
     @Nonnull
-    ItemStack onInsert(ServerPlayerEntity player, ItemStack stack);
+    ItemStack onInsert(ServerPlayerEntity player, ItemStack stack, boolean single);
 
     /**
      * Called when a player is trying to insert an item that it is holding in their hand in the GUI.

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/network/grid/handler/PortableItemGridHandler.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/network/grid/handler/PortableItemGridHandler.java
@@ -28,7 +28,18 @@ public class PortableItemGridHandler implements IItemGridHandler {
     }
 
     @Override
-    public void onExtract(ServerPlayerEntity player, UUID id, int flags) {
+    public void onExtract(ServerPlayerEntity player, ItemStack stack, int preferredSlot, int flags) {
+        if (portableGrid.getStorage() == null || !grid.isActive()) {
+            return;
+        }
+        if (portableGrid.getItemCache().getList().getEntry(stack, IComparer.COMPARE_NBT) != null) {
+            onExtract(player, portableGrid.getItemCache().getList().getEntry(stack, IComparer.COMPARE_NBT).getId(), preferredSlot, flags);
+        }
+
+    }
+
+    @Override
+    public void onExtract(ServerPlayerEntity player, UUID id, int preferredSlot, int flags) {
         if (portableGrid.getStorage() == null || !grid.isActive()) {
             return;
         }
@@ -83,12 +94,24 @@ public class PortableItemGridHandler implements IItemGridHandler {
         if (!took.isEmpty()) {
             if ((flags & EXTRACT_SHIFT) == EXTRACT_SHIFT) {
                 IItemHandler playerInventory = player.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, Direction.UP).orElse(null);
+                if (playerInventory != null) {
+                    if (preferredSlot != -1) {
+                        ItemStack remainder = playerInventory.insertItem(preferredSlot, took, true);
+                        if (remainder.getCount() != took.getCount()) {
+                            ItemStack inserted = portableGrid.getItemStorage().extract(item, size - remainder.getCount(), IComparer.COMPARE_NBT, Action.PERFORM);
+                            playerInventory.insertItem(preferredSlot, inserted, false);
+                            took.setCount(remainder.getCount());
+                        }
+                    }
+                    if (!took.isEmpty()) {
+                        if (ItemHandlerHelper.insertItemStacked(playerInventory, took, true).isEmpty()) {
+                            took = portableGrid.getItemStorage().extract(item, size, IComparer.COMPARE_NBT, Action.PERFORM);
 
-                if (playerInventory != null && ItemHandlerHelper.insertItem(playerInventory, took, true).isEmpty()) {
-                    took = portableGrid.getItemStorage().extract(item, size, IComparer.COMPARE_NBT, Action.PERFORM);
-
-                    ItemHandlerHelper.insertItem(playerInventory, took, false);
+                            ItemHandlerHelper.insertItemStacked(playerInventory, took, false);
+                        }
+                    }
                 }
+
             } else {
                 took = portableGrid.getItemStorage().extract(item, size, IComparer.COMPARE_NBT, Action.PERFORM);
 
@@ -107,14 +130,22 @@ public class PortableItemGridHandler implements IItemGridHandler {
 
     @Override
     @Nonnull
-    public ItemStack onInsert(ServerPlayerEntity player, ItemStack stack) {
+    public ItemStack onInsert(ServerPlayerEntity player, ItemStack stack, boolean single) {
         if (portableGrid.getStorage() == null || !grid.isActive()) {
             return stack;
         }
 
         portableGrid.getItemStorageTracker().changed(player, stack.copy());
-
-        ItemStack remainder = portableGrid.getItemStorage().insert(stack, stack.getCount(), Action.PERFORM);
+        ItemStack remainder;
+        if (single) {
+            if (portableGrid.getItemStorage().insert(stack, 1, Action.SIMULATE).isEmpty()) {
+                portableGrid.getItemStorage().insert(stack, 1, Action.PERFORM);
+                stack.shrink(1);
+            }
+            remainder = stack;
+        } else {
+            remainder = portableGrid.getItemStorage().insert(stack, stack.getCount(), Action.PERFORM);
+        }
 
         portableGrid.drainEnergy(RS.SERVER_CONFIG.getPortableGrid().getInsertUsage());
 

--- a/src/main/java/com/raoulvdberge/refinedstorage/container/GridContainer.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/container/GridContainer.java
@@ -93,7 +93,7 @@ public class GridContainer extends BaseContainer implements ICraftingGridListene
                             IItemGridHandler itemHandler = grid.getItemHandler();
 
                             if (itemHandler != null) {
-                                slot.putStack(itemHandler.onInsert((ServerPlayerEntity) getPlayer(), stack));
+                                slot.putStack(itemHandler.onInsert((ServerPlayerEntity) getPlayer(), stack, false));
                             } else if (slot instanceof CraftingGridSlot && mergeItemStack(stack, 14, 14 + (9 * 4), false)) {
                                 slot.onSlotChanged();
 

--- a/src/main/java/com/raoulvdberge/refinedstorage/network/NetworkHandler.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/network/NetworkHandler.java
@@ -37,6 +37,8 @@ public class NetworkHandler {
         handler.registerMessage(id++, GridItemUpdateMessage.class, GridItemUpdateMessage::encode, GridItemUpdateMessage::decode, GridItemUpdateMessage::handle);
         handler.registerMessage(id++, GridItemDeltaMessage.class, GridItemDeltaMessage::encode, GridItemDeltaMessage::decode, GridItemDeltaMessage::handle);
         handler.registerMessage(id++, GridItemPullMessage.class, GridItemPullMessage::encode, GridItemPullMessage::decode, GridItemPullMessage::handle);
+        handler.registerMessage(id++, GridItemGridScrollMessage.class, GridItemGridScrollMessage::encode, GridItemGridScrollMessage::decode, GridItemGridScrollMessage::handle);
+        handler.registerMessage(id++, GridItemInventoryScrollMessage.class, GridItemInventoryScrollMessage::encode, GridItemInventoryScrollMessage::decode, GridItemInventoryScrollMessage::handle);
         handler.registerMessage(id++, GridItemInsertHeldMessage.class, GridItemInsertHeldMessage::encode, GridItemInsertHeldMessage::decode, GridItemInsertHeldMessage::handle);
         handler.registerMessage(id++, GridClearMessage.class, GridClearMessage::encode, GridClearMessage::decode, GridClearMessage::handle);
         handler.registerMessage(id++, GridPatternCreateMessage.class, GridPatternCreateMessage::encode, GridPatternCreateMessage::decode, GridPatternCreateMessage::handle);

--- a/src/main/java/com/raoulvdberge/refinedstorage/network/grid/GridItemGridScrollMessage.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/network/grid/GridItemGridScrollMessage.java
@@ -1,0 +1,94 @@
+package com.raoulvdberge.refinedstorage.network.grid;
+
+import com.raoulvdberge.refinedstorage.api.network.grid.IGrid;
+import com.raoulvdberge.refinedstorage.apiimpl.network.grid.handler.ItemGridHandler;
+import com.raoulvdberge.refinedstorage.apiimpl.storage.cache.ItemStorageCache;
+import com.raoulvdberge.refinedstorage.container.GridContainer;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.inventory.container.Container;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.PacketBuffer;
+import net.minecraftforge.fml.network.NetworkEvent;
+
+import java.util.UUID;
+import java.util.function.Supplier;
+
+public class GridItemGridScrollMessage {
+
+    private UUID id;
+    private boolean shift;
+    private boolean up;
+    private boolean ctrl;
+
+
+    public GridItemGridScrollMessage(UUID id, boolean shift, boolean ctrl, boolean up) {
+        this.id = id;
+        this.shift = shift;
+        this.ctrl = ctrl;
+        this.up = up;
+    }
+
+    public static GridItemGridScrollMessage decode(PacketBuffer buf) {
+        return new GridItemGridScrollMessage(buf.readUniqueId(), buf.readBoolean(), buf.readBoolean(), buf.readBoolean());
+    }
+
+    public static void encode(GridItemGridScrollMessage message, PacketBuffer buf) {
+        buf.writeUniqueId(message.id);
+        buf.writeBoolean(message.shift);
+        buf.writeBoolean(message.ctrl);
+        buf.writeBoolean(message.up);
+
+    }
+
+    public static void handle(GridItemGridScrollMessage message, Supplier<NetworkEvent.Context> ctx) {
+        ServerPlayerEntity player = ctx.get().getSender();
+
+        if (player != null) {
+            ctx.get().enqueueWork(() -> {
+                Container container = player.openContainer;
+
+                if (container instanceof GridContainer) {
+                    IGrid grid = ((GridContainer) container).getGrid();
+
+                    if (grid.getItemHandler() != null) {
+                        int flags = ItemGridHandler.EXTRACT_SINGLE;
+                        if (!message.id.equals(new UUID(0, 0))) { //isOverStack
+                            if (message.shift && !message.ctrl) { //shift
+                                flags |= ItemGridHandler.EXTRACT_SHIFT;
+                                if (message.up) { //scroll up
+                                    ItemStorageCache cache = (ItemStorageCache) grid.getStorageCache();
+                                    if (cache != null) {
+                                        ItemStack stack = cache.getList().get(message.id);
+                                        if (stack != null) {
+                                            int slot = player.inventory.getSlotFor(stack);
+                                            if (slot != -1) {
+                                                grid.getItemHandler().onInsert(player, player.inventory.getStackInSlot(slot), true);
+                                                return;
+                                            }
+                                        }
+                                    }
+                                } else { //scroll down
+                                    grid.getItemHandler().onExtract(player, message.id, -1, flags);
+                                    return;
+                                }
+                            } else { //ctrl
+                                if (!message.up) { //scroll down
+                                    grid.getItemHandler().onExtract(player, message.id, -1, flags);
+                                    return;
+                                }
+                            }
+                        }
+                        if (message.up) { //scroll up
+                            grid.getItemHandler().onInsert(player, player.inventory.getItemStack(), true);
+                            player.inventory.getItemStack().shrink(1);
+                            player.updateHeldItem();
+                        }
+
+                    }
+                }
+            });
+        }
+
+        ctx.get().setPacketHandled(true);
+    }
+}

--- a/src/main/java/com/raoulvdberge/refinedstorage/network/grid/GridItemGridScrollMessage.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/network/grid/GridItemGridScrollMessage.java
@@ -80,7 +80,6 @@ public class GridItemGridScrollMessage {
                         }
                         if (message.up) { //scroll up
                             grid.getItemHandler().onInsert(player, player.inventory.getItemStack(), true);
-                            player.inventory.getItemStack().shrink(1);
                             player.updateHeldItem();
                         }
 

--- a/src/main/java/com/raoulvdberge/refinedstorage/network/grid/GridItemInventoryScrollMessage.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/network/grid/GridItemInventoryScrollMessage.java
@@ -1,0 +1,80 @@
+package com.raoulvdberge.refinedstorage.network.grid;
+
+import com.raoulvdberge.refinedstorage.api.network.grid.IGrid;
+import com.raoulvdberge.refinedstorage.apiimpl.network.grid.handler.ItemGridHandler;
+import com.raoulvdberge.refinedstorage.container.GridContainer;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.inventory.container.Container;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.PacketBuffer;
+import net.minecraftforge.fml.network.NetworkEvent;
+
+import java.util.function.Supplier;
+
+public class GridItemInventoryScrollMessage {
+    private int slot;
+    private boolean shift;
+    private boolean up;
+
+    public GridItemInventoryScrollMessage(int slot, boolean shift, boolean up) {
+        this.slot = slot;
+        this.shift = shift;
+        this.up = up;
+    }
+
+    public static GridItemInventoryScrollMessage decode(PacketBuffer buf) {
+        return new GridItemInventoryScrollMessage(buf.readInt(), buf.readBoolean(), buf.readBoolean());
+    }
+
+    public static void encode(GridItemInventoryScrollMessage message, PacketBuffer buf) {
+        buf.writeInt(message.slot);
+        buf.writeBoolean(message.shift);
+        buf.writeBoolean(message.up);
+    }
+
+    public static void handle(GridItemInventoryScrollMessage message, Supplier<NetworkEvent.Context> ctx) {
+        ServerPlayerEntity player = ctx.get().getSender();
+
+        if (player != null) {
+            ctx.get().enqueueWork(() -> {
+                Container container = player.openContainer;
+
+                if (container instanceof GridContainer) {
+                    IGrid grid = ((GridContainer) container).getGrid();
+
+                    if (grid.getItemHandler() != null) {
+                        int flags = ItemGridHandler.EXTRACT_SINGLE;
+                        int slot = message.slot;
+                        ItemStack stackInSlot = player.inventory.getStackInSlot(slot);
+                        ItemStack stackOnCursor = player.inventory.getItemStack();
+
+                        if (message.shift) { // shift
+                            flags |= ItemGridHandler.EXTRACT_SHIFT;
+                            if (message.up) { // scroll up
+                                player.inventory.setInventorySlotContents(slot, grid.getItemHandler().onInsert(player, stackInSlot, true));
+                            } else { // scroll down
+                                grid.getItemHandler().onExtract(player, stackInSlot, slot, flags);
+                            }
+
+                        } else { //ctrl
+                            if (message.up) { // scroll up
+                                grid.getItemHandler().onInsert(player, stackOnCursor, true);
+                                player.updateHeldItem();
+                            } else { //scroll down
+                                if (stackOnCursor.isEmpty()) {
+                                    grid.getItemHandler().onExtract(player, stackInSlot, -1, flags);
+                                } else {
+                                    grid.getItemHandler().onExtract(player, stackOnCursor, -1, flags);
+                                }
+
+                            }
+
+                        }
+                    }
+                }
+            });
+        }
+
+        ctx.get().setPacketHandled(true);
+    }
+}

--- a/src/main/java/com/raoulvdberge/refinedstorage/network/grid/GridItemPullMessage.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/network/grid/GridItemPullMessage.java
@@ -39,12 +39,12 @@ public class GridItemPullMessage {
                     IGrid grid = ((GridContainer) container).getGrid();
 
                     if (grid.getItemHandler() != null) {
-                        grid.getItemHandler().onExtract(player, message.id, message.flags);
+                        grid.getItemHandler().onExtract(player, message.id, -1, message.flags);
                     }
                 }
             });
         }
-        
+
         ctx.get().setPacketHandled(true);
     }
 }

--- a/src/main/java/com/raoulvdberge/refinedstorage/screen/AmountSpecifyingScreen.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/screen/AmountSpecifyingScreen.java
@@ -165,6 +165,16 @@ public abstract class AmountSpecifyingScreen<T extends Container> extends BaseSc
         // NO OP
     }
 
+    @Override
+    public boolean mouseScrolled(double x, double y, double delta) {
+        if (delta > 0) {
+            onIncrementButtonClicked(1);
+        } else {
+            onIncrementButtonClicked(-1);
+        }
+        return super.mouseScrolled(x, y, delta);
+    }
+
     public void close() {
         minecraft.displayGuiScreen(parent);
     }

--- a/src/main/java/com/raoulvdberge/refinedstorage/screen/grid/GridScreen.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/screen/grid/GridScreen.java
@@ -38,11 +38,13 @@ import net.minecraft.util.SoundEvents;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraftforge.fml.client.config.GuiCheckBox;
 import org.lwjgl.glfw.GLFW;
+import yalter.mousetweaks.api.MouseTweaksDisableWheelTweak;
 
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
 
+@MouseTweaksDisableWheelTweak
 public class GridScreen extends BaseScreen<GridContainer> implements IScreenInfoProvider {
     private IGridView view;
 


### PR DESCRIPTION
Implemented according to this schema
<details><p><summary> schema </summary>

**Cursor over grid:** 
shift scroll up: pull hovering item from Inventory
shift scroll down: push hovering item from RS into inventory

ctrl scroll up: deposit item from cursor into grid
ctrl scroll down: pull hovering item from grid onto cursor

**Cursor over inventory:** 
shift scroll up: push hovering item into grid 
shift scroll down: pull hovering item from grid

ctrl scroll up: push from cursor to grid
ctrl scroll down: pull hovering item from grid to Cursor
</p></details>

Not sure where to put all the code. Currently just sitting in the handle method of each message. 

Contains a minor change to how items are pulled from the grid in general. They will now first fill all stacks in inventory before adding a new one. 