### PR TITLE
Fix extractFluid voiding excess in OC driver

### DIFF
--- a/src/main/java/com/raoulvdberge/refinedstorage/integration/oc/EnvironmentNetwork.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/integration/oc/EnvironmentNetwork.java
@@ -258,10 +258,16 @@ public class EnvironmentNetwork extends AbstractManagedEnvironment {
         }
 
         // Actually do it and return how much fluid we've inserted
-        FluidStack extracted = node.getNetwork().extractFluid(stack, stack.amount, Action.PERFORM);
-        handler.fill(extracted, true);
+        FluidStack extractedActual = node.getNetwork().extractFluid(stack, filledAmountSim, Action.PERFORM);
+        int filledAmountActual = handler.fill(extractedActual, true);
 
-        return new Object[]{filledAmountSim};
+        // Attempt to insert excess fluid back into the network
+        // This shouldn't need to happen for most tanks, unless input cap decreases based on insert amount
+        if (extractedActual != null && extractedActual.amount > filledAmountActual) {
+            node.getNetwork().insertFluid(stack, extractedActual.amount - filledAmountActual, Action.PERFORM);
+        }
+
+        return new Object[]{filledAmountActual};
     }
 
     @Callback(doc = "function(stack:table):table -- Gets a fluid from the network.")


### PR DESCRIPTION
## Description
Using the OC driver, if you extract more fluid than can fit in a tank it would void the excess.

This PR makes it so it only extracts from the network as much as can be inserted into the tank.

In the edge case that a tank varies its input limit based on how much fluid is being inserted, the excess fluid will attempted to be inserted back into the network.

## Mod Versions (used for testing)
minecraft-1.12.2
forge-14.23.5.2847
refinedstorage-1.6.15
OpenComputers-MC1.12.2-1.7.5.192
extrautils2-1.12-1.9.9

## Demonstration Videos
[Before Fix](https://www.youtube.com/watch?v=_wUAqh8vWo0)
[After Fix](https://www.youtube.com/watch?v=iNNFwOVLhzk)