### PR TITLE
Potential fix NPE in ItemGridView::postChange occurring on client.

### DIFF
--- a/src/main/java/com/raoulvdberge/refinedstorage/screen/grid/view/ItemGridView.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/screen/grid/view/ItemGridView.java
@@ -32,7 +32,10 @@ public class ItemGridView extends BaseGridView {
         // With that new id, the reference for the crafting stack would be outdated.
         if (!stack.isCraftable() &&
             stack.getOtherId() != null) {
-            map.get(stack.getOtherId()).updateOtherId(stack.getId());
+            IGridStack result = map.get(stack.getOtherId());
+            if (result != null) {
+                result.updateOtherId(stack.getId());
+            }
         }
 
         ItemGridStack existing = (ItemGridStack) map.get(stack.getId());


### PR DESCRIPTION
This appears to happen when the contents of the grid previously
contained items that were also ingredients for an autocrafting recipe,
and the autocrafting recipe has been created.

Based on the null check in the block of code after the one edited, it
seems to be a thing that the map can potentially return a null result;
however, the "update other id" block does not test for null, simply
calling `updateOtherId`.

This commit adds a test for a potential null result from the map.

While this might just be addressing the side effect of a larger issue
associated with auto-crafting (i.e., the expectation that the IGridStack
wouldn't be a null result), it hopefully reduces the number of annyoing
client-side crashes.

-> After some extensive testing in a situation where I was getting multiple crashes per gaming session, using this modification seems to have reduced them to nothing.