### PR TITLE
[1.12] Fix Inventory Tweaks woes

### DIFF
--- a/src/main/java/com/raoulvdberge/refinedstorage/container/ContainerBase.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/container/ContainerBase.java
@@ -57,7 +57,17 @@ public abstract class ContainerBase extends Container {
     }
 
     protected void addPlayerInventory(int xInventory, int yInventory) {
-        int id = 0;
+        int id = 9;
+        
+        for (int y = 0; y < 3; y++) {
+            for (int x = 0; x < 9; x++) {
+                addSlotToContainer(new Slot(player.inventory, id, xInventory + x * 18, yInventory + y * 18));
+
+                id++;
+            }
+        }
+        
+        id = 0;
 
         for (int i = 0; i < 9; i++) {
             int x = xInventory + i * 18;
@@ -70,14 +80,6 @@ public abstract class ContainerBase extends Container {
             }
 
             id++;
-        }
-
-        for (int y = 0; y < 3; y++) {
-            for (int x = 0; x < 9; x++) {
-                addSlotToContainer(new Slot(player.inventory, id, xInventory + x * 18, yInventory + y * 18));
-
-                id++;
-            }
         }
     }
 


### PR DESCRIPTION
There has been a long-standing bug with Inventory Tweaks (#2014, Inventory-Tweaks/inventory-tweaks#500) where sorting in a Refined Storage grid would not respect locked slots, and this PR fixes that. The problem was that you added the hotbar slot first, followed by the other slots, whereas it really should be the other way around.