### PR TITLE
Add forge:silicon tag for mod compatibility

### DIFF
--- a/src/main/resources/data/forge/tags/items/silicon.json
+++ b/src/main/resources/data/forge/tags/items/silicon.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "refinedstorage:silicon"
+  ]
+}


### PR DESCRIPTION
Replacement for `ore:itemSilicon` in previous versions. Adds compatibility with Mystical Agriculture silicon seeds.