### PR TITLE
Move FinishCalculation from first update to the end of calculation to fix crash

### DIFF
--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/task/v6/CraftingTask.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/task/v6/CraftingTask.java
@@ -261,6 +261,13 @@ public class CraftingTask implements ICraftingTask {
             this.toCraftFluids.add(req);
         }
 
+        crafts.values().forEach(c -> {
+            totalSteps += c.getQuantity();
+            if (c instanceof Processing) {
+                ((Processing) c).finishCalculation();
+            }
+        });
+
         return null;
     }
 
@@ -916,13 +923,6 @@ public class CraftingTask implements ICraftingTask {
 
         if (executionStarted == -1) {
             executionStarted = System.currentTimeMillis();
-
-            crafts.values().forEach(c -> {
-                totalSteps += c.getQuantity();
-                if (c instanceof Processing) {
-                    ((Processing) c).finishCalculation();
-                }
-            });
         }
 
         ++ticks;


### PR DESCRIPTION
The crash occurred when a new task was started while someone was watching in a crafting monitor when a task was sending an update message that included a task that hasn't run its first update yet. 

Moving the code from first update to end of calculation makes sure the data is available there too. 

Potentially it would be a nice performance improvement to not send data about crafting tasks that aren't actually being changed. With the new engine I don't believe this will be problematic but for the old engine this would be a worthwhile improvement. 