### PR TITLE
fix bug that breaks preview if items are missing

### DIFF
--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/task/v6/CraftingTask.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/autocrafting/task/v6/CraftingTask.java
@@ -260,13 +260,14 @@ public class CraftingTask implements ICraftingTask {
             req.setAmount(qty);
             this.toCraftFluids.add(req);
         }
-
-        crafts.values().forEach(c -> {
-            totalSteps += c.getQuantity();
-            if (c instanceof Processing) {
-                ((Processing) c).finishCalculation();
-            }
-        });
+        if(missing.isEmpty()){
+            crafts.values().forEach(c -> {
+                totalSteps += c.getQuantity();
+                if (c instanceof Processing) {
+                    ((Processing) c).finishCalculation();
+                }
+            });
+        }
 
         return null;
     }


### PR DESCRIPTION
Should have been part of #2500 

I should have really remembered that. It was the reason I moved this into update in the first place.