### PR TITLE
fix stackoverflow caused by exporter with regulator upgrade fixes #2537

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/node/ExporterNetworkNode.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/node/ExporterNetworkNode.java
@@ -40,7 +40,7 @@ public class ExporterNetworkNode extends NetworkNode implements IComparable, ITy
     private UpgradeItemHandler upgrades = (UpgradeItemHandler) new UpgradeItemHandler(4, UpgradeItem.Type.SPEED, UpgradeItem.Type.CRAFTING, UpgradeItem.Type.STACK, UpgradeItem.Type.REGULATOR)
         .addListener(new NetworkNodeInventoryListener(this))
         .addListener((handler, slot, reading) -> {
-            if (!getUpgrades().hasUpgrade(UpgradeItem.Type.REGULATOR)) {
+            if (!reading && !getUpgrades().hasUpgrade(UpgradeItem.Type.REGULATOR)) {
                 boolean changed = false;
 
                 for (int i = 0; i < itemFilters.getSlots(); ++i) {


### PR DESCRIPTION
The issue was that when reading the upgrade item handler listener gets called while the regulator upgrade wasn't detected yet. I.E when another upgrade was read first.  