### PR TITLE
Fix shiftcrafting not using player

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/grid/CraftingGridBehavior.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/grid/CraftingGridBehavior.java
@@ -15,6 +15,7 @@ import net.minecraft.inventory.InventoryHelper;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.ICraftingRecipe;
 import net.minecraft.util.NonNullList;
+import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.fml.hooks.BasicEventHooks;
 import net.minecraftforge.items.ItemHandlerHelper;
 
@@ -74,6 +75,7 @@ public class CraftingGridBehavior implements ICraftingGridBehavior {
         int amountCrafted = 0;
         ItemStack crafted = grid.getCraftingResult().getStackInSlot(0);
 
+        ForgeHooks.setCraftingPlayer(player);
         // Do while the item is still craftable (aka is the result slot still the same as the original item?) and we don't exceed the max stack size.
         do {
             grid.onCrafted(player);
@@ -100,6 +102,7 @@ public class CraftingGridBehavior implements ICraftingGridBehavior {
         // For regular crafting, this is already called in ResultCraftingGridSlot#onTake -> onCrafting(stack)
         crafted.onCrafting(player.world, player, amountCrafted);
         BasicEventHooks.firePlayerCraftingEvent(player, ItemHandlerHelper.copyStackWithSize(crafted, amountCrafted), grid.getCraftingMatrix());
+        ForgeHooks.setCraftingPlayer(null);
     }
 
     @Override


### PR DESCRIPTION
You missed this part when copying from `CraftingResultSlot#onTake`.

Although it is surprising that it took this long for it to pop up. 