### PR TITLE
fix ConstructorNetworkNode not extracting on placement

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/node/ConstructorNetworkNode.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/node/ConstructorNetworkNode.java
@@ -120,7 +120,7 @@ public class ConstructorNetworkNode extends NetworkNode implements IComparable, 
 
             ActionResultType result = ForgeHooks.onPlaceItemIntoWorld(ctx);
             if (result == ActionResultType.SUCCESS) {
-                network.extractItem(took, 1, Action.PERFORM);
+                network.extractItem(stack, 1, Action.PERFORM);
             }
         } else if (upgrades.hasUpgrade(UpgradeItem.Type.CRAFTING)) {
             ItemStack craft = itemFilters.getStackInSlot(0);


### PR DESCRIPTION
Didn't think onPlaceItemIntoWorld would modify the stack. 