### PR TITLE
fix CrafterManagerContainer accepting items other than CraftingPattern

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/container/CrafterManagerContainer.java
+++ b/src/main/java/com/refinedmods/refinedstorage/container/CrafterManagerContainer.java
@@ -175,7 +175,9 @@ public class CrafterManagerContainer extends BaseContainer {
 
         if (slot.getHasStack()) {
             stack = slot.getStack();
-
+            if (!new PatternItemValidator(getPlayer().getEntityWorld()).test(stack)) {
+                return ItemStack.EMPTY;
+            }
             if (index < 9 * 4) {
                 if (!mergeItemStack(stack, 9 * 4, inventorySlots.size(), false)) {
                     return ItemStack.EMPTY;


### PR DESCRIPTION
fixes #2594

`mergeItemStack` doesn't check if insertion is valid. So we manually need to do that beforehand. 