### PR TITLE
fix more ConstructorNetworkNode duping

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/node/ConstructorNetworkNode.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/node/ConstructorNetworkNode.java
@@ -118,7 +118,7 @@ public class ConstructorNetworkNode extends NetworkNode implements IComparable, 
             );
 
             ActionResultType result = ForgeHooks.onPlaceItemIntoWorld(ctx);
-            if (result == ActionResultType.SUCCESS) {
+            if (result.isSuccessOrConsume()) {
                 network.extractItem(stack, 1, Action.PERFORM);
             }
         } else if (upgrades.hasUpgrade(UpgradeItem.Type.CRAFTING)) {


### PR DESCRIPTION
Was SUCCESS is now CONSUME. (That means we are duping items again :D)

By checking both we save headaches with other mods not noticing the change (its also what vanilla uses). 

There are more places where it might be sensible to change from SUCCESS to CONSUME but as far as I can tell none are critical. 