### PR TITLE
Allow extending for all the blocks

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/block/CableBlock.java
+++ b/src/main/java/com/refinedmods/refinedstorage/block/CableBlock.java
@@ -16,6 +16,7 @@ import net.minecraft.state.BooleanProperty;
 import net.minecraft.state.StateContainer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
@@ -55,10 +56,10 @@ public class CableBlock extends NetworkNodeBlock implements IWaterLoggable {
         this.setDefaultState(getDefaultState().with(WATERLOGGED, false));
     }
 
-    public CableBlock() {
+    public CableBlock(ResourceLocation registryName) {
         super(BlockUtils.DEFAULT_GLASS_PROPERTIES);
 
-        this.setRegistryName(RS.ID, "cable");
+        this.setRegistryName(registryName);
         this.setDefaultState(getDefaultState().with(NORTH, false).with(EAST, false).with(SOUTH, false).with(WEST, false).with(UP, false).with(DOWN, false).with(WATERLOGGED, false));
     }
 

--- a/src/main/java/com/refinedmods/refinedstorage/block/ConstructorBlock.java
+++ b/src/main/java/com/refinedmods/refinedstorage/block/ConstructorBlock.java
@@ -15,6 +15,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Direction;
 import net.minecraft.util.Hand;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.util.math.shapes.ISelectionContext;
@@ -35,10 +36,10 @@ public class ConstructorBlock extends CableBlock {
     private static final VoxelShape HEAD_DOWN = VoxelShapes.or(makeCuboidShape(2, 0, 2, 14, 2, 14), HOLDER_DOWN);
     private static final VoxelShape HEAD_UP = VoxelShapes.or(makeCuboidShape(2, 14, 2, 14, 16, 14), HOLDER_UP);
 
-    public ConstructorBlock() {
+    public ConstructorBlock(ResourceLocation registryName) {
         super(BlockUtils.DEFAULT_GLASS_PROPERTIES);
 
-        this.setRegistryName(RS.ID, "constructor");
+        this.setRegistryName(registryName);
     }
 
     @Override

--- a/src/main/java/com/refinedmods/refinedstorage/block/ControllerBlock.java
+++ b/src/main/java/com/refinedmods/refinedstorage/block/ControllerBlock.java
@@ -24,6 +24,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Hand;
 import net.minecraft.util.IStringSerializable;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.util.text.ITextComponent;
@@ -64,11 +65,11 @@ public class ControllerBlock extends BaseBlock {
 
     private final NetworkType type;
 
-    public ControllerBlock(NetworkType type) {
+    public ControllerBlock(NetworkType type, ResourceLocation registryName) {
         super(BlockUtils.DEFAULT_ROCK_PROPERTIES);
 
         this.type = type;
-        this.setRegistryName(RS.ID, type == NetworkType.CREATIVE ? "creative_controller" : "controller");
+        this.setRegistryName(registryName);
         this.setDefaultState(getStateContainer().getBaseState().with(ENERGY_TYPE, EnergyType.OFF));
     }
 

--- a/src/main/java/com/refinedmods/refinedstorage/block/CrafterBlock.java
+++ b/src/main/java/com/refinedmods/refinedstorage/block/CrafterBlock.java
@@ -15,6 +15,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Hand;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.world.IBlockReader;
@@ -24,10 +25,10 @@ import net.minecraftforge.fml.network.NetworkHooks;
 import javax.annotation.Nullable;
 
 public class CrafterBlock extends NetworkNodeBlock {
-    public CrafterBlock() {
+    public CrafterBlock(ResourceLocation registryName) {
         super(BlockUtils.DEFAULT_ROCK_PROPERTIES);
 
-        this.setRegistryName(RS.ID, "crafter");
+        this.setRegistryName(registryName);
     }
 
     @Override

--- a/src/main/java/com/refinedmods/refinedstorage/block/CrafterManagerBlock.java
+++ b/src/main/java/com/refinedmods/refinedstorage/block/CrafterManagerBlock.java
@@ -12,6 +12,7 @@ import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Hand;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.world.IBlockReader;
@@ -21,10 +22,10 @@ import net.minecraftforge.fml.network.NetworkHooks;
 import javax.annotation.Nullable;
 
 public class CrafterManagerBlock extends NetworkNodeBlock {
-    public CrafterManagerBlock() {
+    public CrafterManagerBlock(ResourceLocation registryName) {
         super(BlockUtils.DEFAULT_ROCK_PROPERTIES);
 
-        this.setRegistryName(RS.ID, "crafter_manager");
+        this.setRegistryName(registryName);
     }
 
     @Override

--- a/src/main/java/com/refinedmods/refinedstorage/block/CraftingMonitorBlock.java
+++ b/src/main/java/com/refinedmods/refinedstorage/block/CraftingMonitorBlock.java
@@ -13,6 +13,7 @@ import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Hand;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.world.IBlockReader;
@@ -22,10 +23,10 @@ import net.minecraftforge.fml.network.NetworkHooks;
 import javax.annotation.Nullable;
 
 public class CraftingMonitorBlock extends NetworkNodeBlock {
-    public CraftingMonitorBlock() {
+    public CraftingMonitorBlock(ResourceLocation registryName) {
         super(BlockUtils.DEFAULT_ROCK_PROPERTIES);
 
-        this.setRegistryName(RS.ID, "crafting_monitor");
+        this.setRegistryName(registryName);
     }
 
     @Override

--- a/src/main/java/com/refinedmods/refinedstorage/block/DestructorBlock.java
+++ b/src/main/java/com/refinedmods/refinedstorage/block/DestructorBlock.java
@@ -15,6 +15,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Direction;
 import net.minecraft.util.Hand;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.util.math.shapes.ISelectionContext;
@@ -35,10 +36,10 @@ public class DestructorBlock extends CableBlock {
     private static final VoxelShape HEAD_DOWN = VoxelShapes.or(makeCuboidShape(2, 0, 2, 14, 2, 14), HOLDER_DOWN);
     private static final VoxelShape HEAD_UP = VoxelShapes.or(makeCuboidShape(2, 14, 2, 14, 16, 14), HOLDER_UP);
 
-    public DestructorBlock() {
+    public DestructorBlock(ResourceLocation registryName) {
         super(BlockUtils.DEFAULT_GLASS_PROPERTIES);
 
-        this.setRegistryName(RS.ID, "destructor");
+        this.setRegistryName(registryName);
     }
 
     @Override

--- a/src/main/java/com/refinedmods/refinedstorage/block/DetectorBlock.java
+++ b/src/main/java/com/refinedmods/refinedstorage/block/DetectorBlock.java
@@ -16,6 +16,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Direction;
 import net.minecraft.util.Hand;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.util.math.shapes.ISelectionContext;
@@ -32,10 +33,10 @@ public class DetectorBlock extends NetworkNodeBlock {
 
     private static final VoxelShape SHAPE = makeCuboidShape(0, 0, 0, 16, 5, 16);
 
-    public DetectorBlock() {
+    public DetectorBlock(ResourceLocation registryName) {
         super(BlockUtils.DEFAULT_ROCK_PROPERTIES);
 
-        this.setRegistryName(RS.ID, "detector");
+        this.setRegistryName(registryName);
         this.setDefaultState(this.getStateContainer().getBaseState().with(POWERED, false));
     }
 

--- a/src/main/java/com/refinedmods/refinedstorage/block/DiskDriveBlock.java
+++ b/src/main/java/com/refinedmods/refinedstorage/block/DiskDriveBlock.java
@@ -12,6 +12,7 @@ import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Hand;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.util.text.TranslationTextComponent;
@@ -22,10 +23,10 @@ import net.minecraftforge.fml.network.NetworkHooks;
 import javax.annotation.Nullable;
 
 public class DiskDriveBlock extends NetworkNodeBlock {
-    public DiskDriveBlock() {
+    public DiskDriveBlock(ResourceLocation registryName) {
         super(BlockUtils.DEFAULT_ROCK_PROPERTIES);
 
-        this.setRegistryName(RS.ID, "disk_drive");
+        this.setRegistryName(registryName);
     }
 
     @Override

--- a/src/main/java/com/refinedmods/refinedstorage/block/DiskManipulatorBlock.java
+++ b/src/main/java/com/refinedmods/refinedstorage/block/DiskManipulatorBlock.java
@@ -12,6 +12,7 @@ import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Hand;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.util.text.TranslationTextComponent;
@@ -22,10 +23,10 @@ import net.minecraftforge.fml.network.NetworkHooks;
 import javax.annotation.Nullable;
 
 public class DiskManipulatorBlock extends NetworkNodeBlock {
-    public DiskManipulatorBlock() {
+    public DiskManipulatorBlock(ResourceLocation registryName) {
         super(BlockUtils.DEFAULT_ROCK_PROPERTIES);
 
-        this.setRegistryName(RS.ID, "disk_manipulator");
+        this.setRegistryName(registryName);
     }
 
     @Nullable

--- a/src/main/java/com/refinedmods/refinedstorage/block/ExporterBlock.java
+++ b/src/main/java/com/refinedmods/refinedstorage/block/ExporterBlock.java
@@ -15,6 +15,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Direction;
 import net.minecraft.util.Hand;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.util.math.shapes.ISelectionContext;
@@ -58,10 +59,10 @@ public class ExporterBlock extends CableBlock {
     private static final VoxelShape LINE_DOWN_3 = makeCuboidShape(3, 4, 3, 13, 6, 13);
     private static final VoxelShape LINE_DOWN = VoxelShapes.or(LINE_DOWN_1, LINE_DOWN_2, LINE_DOWN_3);
 
-    public ExporterBlock() {
+    public ExporterBlock(ResourceLocation registryName) {
         super(BlockUtils.DEFAULT_GLASS_PROPERTIES);
 
-        this.setRegistryName(RS.ID, "exporter");
+        this.setRegistryName(registryName);
     }
 
     @Override

--- a/src/main/java/com/refinedmods/refinedstorage/block/ExternalStorageBlock.java
+++ b/src/main/java/com/refinedmods/refinedstorage/block/ExternalStorageBlock.java
@@ -19,6 +19,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Direction;
 import net.minecraft.util.Hand;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.util.math.shapes.ISelectionContext;
@@ -39,10 +40,10 @@ public class ExternalStorageBlock extends CableBlock {
     private static final VoxelShape HEAD_UP = VoxelShapes.or(makeCuboidShape(3, 14, 3, 13, 16, 13), HOLDER_UP);
     private static final VoxelShape HEAD_DOWN = VoxelShapes.or(makeCuboidShape(3, 0, 3, 13, 2, 13), HOLDER_DOWN);
 
-    public ExternalStorageBlock() {
+    public ExternalStorageBlock(ResourceLocation registryName) {
         super(BlockUtils.DEFAULT_GLASS_PROPERTIES);
 
-        this.setRegistryName(RS.ID, "external_storage");
+        this.setRegistryName(registryName);
     }
 
     @Override

--- a/src/main/java/com/refinedmods/refinedstorage/block/FluidInterfaceBlock.java
+++ b/src/main/java/com/refinedmods/refinedstorage/block/FluidInterfaceBlock.java
@@ -13,6 +13,7 @@ import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Hand;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.util.text.TranslationTextComponent;
@@ -23,10 +24,10 @@ import net.minecraftforge.fml.network.NetworkHooks;
 import javax.annotation.Nullable;
 
 public class FluidInterfaceBlock extends NetworkNodeBlock {
-    public FluidInterfaceBlock() {
+    public FluidInterfaceBlock(ResourceLocation registryName) {
         super(BlockUtils.DEFAULT_ROCK_PROPERTIES);
 
-        this.setRegistryName(RS.ID, "fluid_interface");
+        this.setRegistryName(registryName);
     }
 
     @Nullable

--- a/src/main/java/com/refinedmods/refinedstorage/block/FluidStorageBlock.java
+++ b/src/main/java/com/refinedmods/refinedstorage/block/FluidStorageBlock.java
@@ -16,6 +16,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Hand;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.world.IBlockReader;
@@ -27,12 +28,12 @@ import javax.annotation.Nullable;
 public class FluidStorageBlock extends NetworkNodeBlock {
     private final FluidStorageType type;
 
-    public FluidStorageBlock(FluidStorageType type) {
+    public FluidStorageBlock(FluidStorageType type, ResourceLocation registryName) {
         super(BlockUtils.DEFAULT_ROCK_PROPERTIES);
 
         this.type = type;
 
-        this.setRegistryName(RS.ID, type.getName() + "_fluid_storage_block");
+        this.setRegistryName(registryName);
     }
 
     public FluidStorageType getType() {

--- a/src/main/java/com/refinedmods/refinedstorage/block/ImporterBlock.java
+++ b/src/main/java/com/refinedmods/refinedstorage/block/ImporterBlock.java
@@ -15,6 +15,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Direction;
 import net.minecraft.util.Hand;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.util.math.shapes.ISelectionContext;
@@ -58,10 +59,10 @@ public class ImporterBlock extends CableBlock {
     private static final VoxelShape LINE_DOWN_3 = makeCuboidShape(3, 0, 3, 13, 2, 13);
     private static final VoxelShape LINE_DOWN = VoxelShapes.or(LINE_DOWN_1, LINE_DOWN_2, LINE_DOWN_3);
 
-    public ImporterBlock() {
+    public ImporterBlock(ResourceLocation registryName) {
         super(BlockUtils.DEFAULT_GLASS_PROPERTIES);
 
-        this.setRegistryName(RS.ID, "importer");
+        this.setRegistryName(registryName);
     }
 
     @Override

--- a/src/main/java/com/refinedmods/refinedstorage/block/InterfaceBlock.java
+++ b/src/main/java/com/refinedmods/refinedstorage/block/InterfaceBlock.java
@@ -13,6 +13,7 @@ import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Hand;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.util.text.TranslationTextComponent;
@@ -23,10 +24,10 @@ import net.minecraftforge.fml.network.NetworkHooks;
 import javax.annotation.Nullable;
 
 public class InterfaceBlock extends NetworkNodeBlock {
-    public InterfaceBlock() {
+    public InterfaceBlock(ResourceLocation registryName) {
         super(BlockUtils.DEFAULT_ROCK_PROPERTIES);
 
-        this.setRegistryName(RS.ID, "interface");
+        this.setRegistryName(registryName);
     }
 
     @Nullable

--- a/src/main/java/com/refinedmods/refinedstorage/block/MachineCasingBlock.java
+++ b/src/main/java/com/refinedmods/refinedstorage/block/MachineCasingBlock.java
@@ -2,11 +2,12 @@ package com.refinedmods.refinedstorage.block;
 
 import com.refinedmods.refinedstorage.RS;
 import com.refinedmods.refinedstorage.util.BlockUtils;
+import net.minecraft.util.ResourceLocation;
 
 public class MachineCasingBlock extends BaseBlock {
-    public MachineCasingBlock() {
+    public MachineCasingBlock(ResourceLocation registryName) {
         super(BlockUtils.DEFAULT_ROCK_PROPERTIES);
 
-        this.setRegistryName(RS.ID, "machine_casing");
+        this.setRegistryName(registryName);
     }
 }

--- a/src/main/java/com/refinedmods/refinedstorage/block/NetworkReceiverBlock.java
+++ b/src/main/java/com/refinedmods/refinedstorage/block/NetworkReceiverBlock.java
@@ -5,15 +5,16 @@ import com.refinedmods.refinedstorage.tile.NetworkReceiverTile;
 import com.refinedmods.refinedstorage.util.BlockUtils;
 import net.minecraft.block.BlockState;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.IBlockReader;
 
 import javax.annotation.Nullable;
 
 public class NetworkReceiverBlock extends NetworkNodeBlock {
-    public NetworkReceiverBlock() {
+    public NetworkReceiverBlock(ResourceLocation registryName) {
         super(BlockUtils.DEFAULT_ROCK_PROPERTIES);
 
-        this.setRegistryName(RS.ID, "network_receiver");
+        this.setRegistryName(registryName);
     }
 
     @Nullable

--- a/src/main/java/com/refinedmods/refinedstorage/block/NetworkTransmitterBlock.java
+++ b/src/main/java/com/refinedmods/refinedstorage/block/NetworkTransmitterBlock.java
@@ -12,6 +12,7 @@ import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Hand;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.util.text.TranslationTextComponent;
@@ -22,10 +23,10 @@ import net.minecraftforge.fml.network.NetworkHooks;
 import javax.annotation.Nullable;
 
 public class NetworkTransmitterBlock extends NetworkNodeBlock {
-    public NetworkTransmitterBlock() {
+    public NetworkTransmitterBlock(ResourceLocation registryName) {
         super(BlockUtils.DEFAULT_ROCK_PROPERTIES);
 
-        this.setRegistryName(RS.ID, "network_transmitter");
+        this.setRegistryName(registryName);
     }
 
     @Nullable

--- a/src/main/java/com/refinedmods/refinedstorage/block/PortableGridBlock.java
+++ b/src/main/java/com/refinedmods/refinedstorage/block/PortableGridBlock.java
@@ -19,6 +19,7 @@ import net.minecraft.state.StateContainer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Hand;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.util.math.shapes.ISelectionContext;
@@ -36,11 +37,11 @@ public class PortableGridBlock extends BaseBlock {
 
     private final PortableGridBlockItem.Type type;
 
-    public PortableGridBlock(PortableGridBlockItem.Type type) {
+    public PortableGridBlock(PortableGridBlockItem.Type type, ResourceLocation registryName) {
         super(BlockUtils.DEFAULT_ROCK_PROPERTIES);
 
         this.type = type;
-        this.setRegistryName(RS.ID, (type == PortableGridBlockItem.Type.CREATIVE ? "creative_" : "") + "portable_grid");
+        this.setRegistryName(registryName);
         this.setDefaultState(getDefaultState().with(DISK_STATE, PortableGridDiskState.NONE).with(ACTIVE, false));
     }
 

--- a/src/main/java/com/refinedmods/refinedstorage/block/QuartzEnrichedIronBlock.java
+++ b/src/main/java/com/refinedmods/refinedstorage/block/QuartzEnrichedIronBlock.java
@@ -2,11 +2,12 @@ package com.refinedmods.refinedstorage.block;
 
 import com.refinedmods.refinedstorage.RS;
 import com.refinedmods.refinedstorage.util.BlockUtils;
+import net.minecraft.util.ResourceLocation;
 
 public class QuartzEnrichedIronBlock extends BaseBlock {
-    public QuartzEnrichedIronBlock() {
+    public QuartzEnrichedIronBlock(ResourceLocation registryName) {
         super(BlockUtils.DEFAULT_ROCK_PROPERTIES);
 
-        this.setRegistryName(RS.ID, "quartz_enriched_iron_block");
+        this.setRegistryName(registryName);
     }
 }

--- a/src/main/java/com/refinedmods/refinedstorage/block/RelayBlock.java
+++ b/src/main/java/com/refinedmods/refinedstorage/block/RelayBlock.java
@@ -12,6 +12,7 @@ import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Hand;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.util.text.TranslationTextComponent;
@@ -22,10 +23,10 @@ import net.minecraftforge.fml.network.NetworkHooks;
 import javax.annotation.Nullable;
 
 public class RelayBlock extends NetworkNodeBlock {
-    public RelayBlock() {
+    public RelayBlock(ResourceLocation registryName) {
         super(BlockUtils.DEFAULT_ROCK_PROPERTIES);
 
-        this.setRegistryName(RS.ID, "relay");
+        this.setRegistryName(registryName);
     }
 
     @Nullable

--- a/src/main/java/com/refinedmods/refinedstorage/block/SecurityManagerBlock.java
+++ b/src/main/java/com/refinedmods/refinedstorage/block/SecurityManagerBlock.java
@@ -13,6 +13,7 @@ import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Hand;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.util.text.TranslationTextComponent;
@@ -23,10 +24,10 @@ import net.minecraftforge.fml.network.NetworkHooks;
 import javax.annotation.Nullable;
 
 public class SecurityManagerBlock extends NetworkNodeBlock {
-    public SecurityManagerBlock() {
+    public SecurityManagerBlock(ResourceLocation registryName) {
         super(BlockUtils.DEFAULT_ROCK_PROPERTIES);
 
-        this.setRegistryName(RS.ID, "security_manager");
+        this.setRegistryName(registryName);
     }
 
     @Override

--- a/src/main/java/com/refinedmods/refinedstorage/block/StorageBlock.java
+++ b/src/main/java/com/refinedmods/refinedstorage/block/StorageBlock.java
@@ -16,6 +16,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Hand;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.world.IBlockReader;
@@ -27,12 +28,12 @@ import javax.annotation.Nullable;
 public class StorageBlock extends NetworkNodeBlock {
     private final ItemStorageType type;
 
-    public StorageBlock(ItemStorageType type) {
+    public StorageBlock(ItemStorageType type, ResourceLocation registryName) {
         super(BlockUtils.DEFAULT_ROCK_PROPERTIES);
 
         this.type = type;
 
-        this.setRegistryName(RS.ID, type.getName() + "_storage_block");
+        this.setRegistryName(registryName);
     }
 
     public ItemStorageType getType() {

--- a/src/main/java/com/refinedmods/refinedstorage/block/StorageMonitorBlock.java
+++ b/src/main/java/com/refinedmods/refinedstorage/block/StorageMonitorBlock.java
@@ -15,6 +15,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Hand;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.util.math.RayTraceResult;
@@ -26,10 +27,10 @@ import net.minecraftforge.fml.network.NetworkHooks;
 import javax.annotation.Nullable;
 
 public class StorageMonitorBlock extends NetworkNodeBlock {
-    public StorageMonitorBlock() {
+    public StorageMonitorBlock(ResourceLocation registryName) {
         super(BlockUtils.DEFAULT_ROCK_PROPERTIES);
 
-        this.setRegistryName(RS.ID, "storage_monitor");
+        this.setRegistryName(registryName);
     }
 
     @Override

--- a/src/main/java/com/refinedmods/refinedstorage/block/WirelessTransmitterBlock.java
+++ b/src/main/java/com/refinedmods/refinedstorage/block/WirelessTransmitterBlock.java
@@ -12,6 +12,7 @@ import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Hand;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.util.math.shapes.ISelectionContext;
@@ -32,10 +33,10 @@ public class WirelessTransmitterBlock extends NetworkNodeBlock {
     private static final VoxelShape SHAPE_NORTH = makeCuboidShape(6.0D, 6.0D, 0.0D, 10.0D, 10.0D, 10.0D);
     private static final VoxelShape SHAPE_SOUTH = makeCuboidShape(6.0D, 6.0D, 6.0D, 10.0D, 10.0D, 16.0D);
 
-    public WirelessTransmitterBlock() {
+    public WirelessTransmitterBlock(ResourceLocation registryName) {
         super(BlockUtils.DEFAULT_ROCK_PROPERTIES);
 
-        this.setRegistryName(RS.ID, "wireless_transmitter");
+        this.setRegistryName(registryName);
     }
 
     @Override

--- a/src/main/java/com/refinedmods/refinedstorage/item/NetworkCardItem.java
+++ b/src/main/java/com/refinedmods/refinedstorage/item/NetworkCardItem.java
@@ -1,7 +1,7 @@
 package com.refinedmods.refinedstorage.item;
 
 import com.refinedmods.refinedstorage.RS;
-import com.refinedmods.refinedstorage.RSBlocks;
+import com.refinedmods.refinedstorage.block.NetworkReceiverBlock;
 import com.refinedmods.refinedstorage.render.Styles;
 import net.minecraft.block.Block;
 import net.minecraft.client.util.ITooltipFlag;
@@ -37,7 +37,7 @@ public class NetworkCardItem extends Item {
     public ActionResultType onItemUse(ItemUseContext ctx) {
         Block block = ctx.getWorld().getBlockState(ctx.getPos()).getBlock();
 
-        if (block == RSBlocks.NETWORK_RECEIVER) {
+        if (block instanceof NetworkReceiverBlock) {
             CompoundNBT tag = new CompoundNBT();
 
             tag.putInt(NBT_RECEIVER_X, ctx.getPos().getX());

--- a/src/main/java/com/refinedmods/refinedstorage/setup/CommonSetup.java
+++ b/src/main/java/com/refinedmods/refinedstorage/setup/CommonSetup.java
@@ -153,45 +153,45 @@ public class CommonSetup {
 
     @SubscribeEvent
     public void onRegisterBlocks(RegistryEvent.Register<Block> e) {
-        e.getRegistry().register(new QuartzEnrichedIronBlock());
-        e.getRegistry().register(new ControllerBlock(NetworkType.NORMAL));
-        e.getRegistry().register(new ControllerBlock(NetworkType.CREATIVE));
-        e.getRegistry().register(new MachineCasingBlock());
-        e.getRegistry().register(new CableBlock());
-        e.getRegistry().register(new DiskDriveBlock());
+        e.getRegistry().register(new QuartzEnrichedIronBlock(new ResourceLocation(RS.ID, "quartz_enriched_iron_block")));
+        e.getRegistry().register(new ControllerBlock(NetworkType.NORMAL, new ResourceLocation(RS.ID, "controller")));
+        e.getRegistry().register(new ControllerBlock(NetworkType.CREATIVE, new ResourceLocation(RS.ID, "creative_controller")));
+        e.getRegistry().register(new MachineCasingBlock(new ResourceLocation(RS.ID, "machine_casing")));
+        e.getRegistry().register(new CableBlock(new ResourceLocation(RS.ID, "cable")));
+        e.getRegistry().register(new DiskDriveBlock(new ResourceLocation(RS.ID, "disk_drive")));
         e.getRegistry().register(new GridBlock(GridType.NORMAL, new ResourceLocation(RS.ID, "grid")));
         e.getRegistry().register(new GridBlock(GridType.CRAFTING, new ResourceLocation(RS.ID, GridType.CRAFTING.getString() + "_grid")));
         e.getRegistry().register(new GridBlock(GridType.PATTERN, new ResourceLocation(RS.ID, GridType.PATTERN.getString() + "_grid")));
         e.getRegistry().register(new GridBlock(GridType.FLUID, new ResourceLocation(RS.ID, GridType.FLUID.getString() + "_grid")));
 
         for (ItemStorageType type : ItemStorageType.values()) {
-            e.getRegistry().register(new StorageBlock(type));
+            e.getRegistry().register(new StorageBlock(type, new ResourceLocation(RS.ID, type.getName() + "_storage_block")));
         }
 
         for (FluidStorageType type : FluidStorageType.values()) {
-            e.getRegistry().register(new FluidStorageBlock(type));
+            e.getRegistry().register(new FluidStorageBlock(type, new ResourceLocation(RS.ID, type.getName() + "_fluid_storage_block")));
         }
 
-        e.getRegistry().register(new ExternalStorageBlock());
-        e.getRegistry().register(new ImporterBlock());
-        e.getRegistry().register(new ExporterBlock());
-        e.getRegistry().register(new NetworkReceiverBlock());
-        e.getRegistry().register(new NetworkTransmitterBlock());
-        e.getRegistry().register(new RelayBlock());
-        e.getRegistry().register(new DetectorBlock());
-        e.getRegistry().register(new SecurityManagerBlock());
-        e.getRegistry().register(new InterfaceBlock());
-        e.getRegistry().register(new FluidInterfaceBlock());
-        e.getRegistry().register(new WirelessTransmitterBlock());
-        e.getRegistry().register(new StorageMonitorBlock());
-        e.getRegistry().register(new ConstructorBlock());
-        e.getRegistry().register(new DestructorBlock());
-        e.getRegistry().register(new DiskManipulatorBlock());
-        e.getRegistry().register(new PortableGridBlock(PortableGridBlockItem.Type.NORMAL));
-        e.getRegistry().register(new PortableGridBlock(PortableGridBlockItem.Type.CREATIVE));
-        e.getRegistry().register(new CrafterBlock());
-        e.getRegistry().register(new CrafterManagerBlock());
-        e.getRegistry().register(new CraftingMonitorBlock());
+        e.getRegistry().register(new ExternalStorageBlock(new ResourceLocation(RS.ID, "external_storage")));
+        e.getRegistry().register(new ImporterBlock(new ResourceLocation(RS.ID, "importer")));
+        e.getRegistry().register(new ExporterBlock(new ResourceLocation(RS.ID, "exporter")));
+        e.getRegistry().register(new NetworkReceiverBlock(new ResourceLocation(RS.ID, "network_receiver")));
+        e.getRegistry().register(new NetworkTransmitterBlock(new ResourceLocation(RS.ID, "network_transmitter")));
+        e.getRegistry().register(new RelayBlock(new ResourceLocation(RS.ID, "relay")));
+        e.getRegistry().register(new DetectorBlock(new ResourceLocation(RS.ID, "detector")));
+        e.getRegistry().register(new SecurityManagerBlock(new ResourceLocation(RS.ID, "security_manager")));
+        e.getRegistry().register(new InterfaceBlock(new ResourceLocation(RS.ID, "interface")));
+        e.getRegistry().register(new FluidInterfaceBlock(new ResourceLocation(RS.ID, "fluid_interface")));
+        e.getRegistry().register(new WirelessTransmitterBlock(new ResourceLocation(RS.ID, "wireless_transmitter")));
+        e.getRegistry().register(new StorageMonitorBlock(new ResourceLocation(RS.ID, "storage_monitor")));
+        e.getRegistry().register(new ConstructorBlock(new ResourceLocation(RS.ID, "constructor")));
+        e.getRegistry().register(new DestructorBlock(new ResourceLocation(RS.ID, "destructor")));
+        e.getRegistry().register(new DiskManipulatorBlock(new ResourceLocation(RS.ID, "disk_manipulator")));
+        e.getRegistry().register(new PortableGridBlock(PortableGridBlockItem.Type.NORMAL, new ResourceLocation(RS.ID, "portable_grid")));
+        e.getRegistry().register(new PortableGridBlock(PortableGridBlockItem.Type.CREATIVE, new ResourceLocation(RS.ID, "creative_portable_grid")));
+        e.getRegistry().register(new CrafterBlock(new ResourceLocation(RS.ID, "crafter")));
+        e.getRegistry().register(new CrafterManagerBlock(new ResourceLocation(RS.ID, "crafter_manager")));
+        e.getRegistry().register(new CraftingMonitorBlock(new ResourceLocation(RS.ID, "crafting_monitor")));
     }
 
     @SubscribeEvent


### PR DESCRIPTION
I only "need" like half of them, but I figure making them all work like that is a bit cleaner. 

Currently, just copy-pasting almost the whole block class for these. It works. But it's quite ugly. 

I'm slowly getting close to release:
![image](https://user-images.githubusercontent.com/4283717/92954385-a7a88400-f463-11ea-9f41-820111b3bf71.png)

Also changed the NetworkCardItem to recognize anything extending NetworkReceiverBlock instead of just RS's NetworkReceiver. 

