### PR TITLE
fix portablegrid deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Changed JEI transfer error mechanics (raoulvdberge)
 - Fixed crash when opening Controller GUI (Darkere)
 - Fixed dye being consumed without effect in some cases (Darkere)
+- Fixed deadlock caused by portable grid (Darkere)
 
 ### 1.9.6
 - Port to Minecraft 1.16.3 (raoulvdberge)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Changed JEI transfer error mechanics (raoulvdberge)
 - Fixed crash when opening Controller GUI (Darkere)
 - Fixed dye being consumed without effect in some cases (Darkere)
-- Fixed deadlock caused by portable grid (Darkere)
+- Fixed deadlock caused by Portable Grid (Darkere)
 
 ### 1.9.6
 - Port to Minecraft 1.16.3 (raoulvdberge)

--- a/src/main/java/com/refinedmods/refinedstorage/tile/grid/portable/PortableGridTile.java
+++ b/src/main/java/com/refinedmods/refinedstorage/tile/grid/portable/PortableGridTile.java
@@ -227,11 +227,15 @@ public class PortableGridTile extends BaseTile implements ITickableTileEntity, I
         super.onLoad();
 
         this.loadStorage();
-
-        onTick.add(() -> {
+        if (world.isRemote()) {
             active = isGridActive();
             diskState = getDiskState();
-        });
+        } else {
+            onTick.add(() -> {
+                active = isGridActive();
+                diskState = getDiskState();
+            });
+        }
     }
 
     public void applyDataFromItemToTile(ItemStack stack) {

--- a/src/main/java/com/refinedmods/refinedstorage/tile/grid/portable/PortableGridTile.java
+++ b/src/main/java/com/refinedmods/refinedstorage/tile/grid/portable/PortableGridTile.java
@@ -50,7 +50,6 @@ import com.refinedmods.refinedstorage.tile.grid.GridTile;
 import com.refinedmods.refinedstorage.util.StackUtils;
 import com.refinedmods.refinedstorage.util.WorldUtils;
 import net.minecraft.block.BlockState;
-import net.minecraft.client.renderer.texture.ITickable;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.inventory.CraftResultInventory;
@@ -59,6 +58,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.nbt.ListNBT;
 import net.minecraft.network.datasync.DataSerializers;
+import net.minecraft.tileentity.ITickableTileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TranslationTextComponent;
@@ -77,7 +77,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
-public class PortableGridTile extends BaseTile implements ITickable, IGrid, IPortableGrid, IRedstoneConfigurable, IStorageDiskContainerContext {
+public class PortableGridTile extends BaseTile implements ITickableTileEntity, IGrid, IPortableGrid, IRedstoneConfigurable, IStorageDiskContainerContext {
     public static final TileDataParameter<Integer, PortableGridTile> REDSTONE_MODE = RedstoneMode.createParameter();
     private static final TileDataParameter<Integer, PortableGridTile> SORTING_DIRECTION = new TileDataParameter<>(DataSerializers.VARINT, 0, PortableGridTile::getSortingDirection, (t, v) -> {
         if (IGrid.isValidSortingDirection(v)) {
@@ -757,7 +757,9 @@ public class PortableGridTile extends BaseTile implements ITickable, IGrid, IPor
 
     @Override
     public void tick() {
-        onTick.forEach(Runnable::run);
-        onTick.clear();
+        if (!onTick.isEmpty()) {
+            onTick.forEach(Runnable::run);
+            onTick.clear();
+        }
     }
 }

--- a/src/main/java/com/refinedmods/refinedstorage/tile/grid/portable/PortableGridTile.java
+++ b/src/main/java/com/refinedmods/refinedstorage/tile/grid/portable/PortableGridTile.java
@@ -227,15 +227,11 @@ public class PortableGridTile extends BaseTile implements ITickableTileEntity, I
         super.onLoad();
 
         this.loadStorage();
-        if (world.isRemote()) {
+
+        onTick.add(() -> {
             active = isGridActive();
             diskState = getDiskState();
-        } else {
-            onTick.add(() -> {
-                active = isGridActive();
-                diskState = getDiskState();
-            });
-        }
+        });
     }
 
     public void applyDataFromItemToTile(ItemStack stack) {

--- a/src/main/java/com/refinedmods/refinedstorage/tile/grid/portable/PortableGridTile.java
+++ b/src/main/java/com/refinedmods/refinedstorage/tile/grid/portable/PortableGridTile.java
@@ -171,7 +171,7 @@ public class PortableGridTile extends BaseTile implements ITickableTileEntity, I
 
     private ListNBT enchants = null;
 
-    private final List<Runnable> onTick = new ArrayList<>();
+    private boolean loadNextTick;
 
     public PortableGridTile(PortableGridBlockItem.Type type) {
         super(type == PortableGridBlockItem.Type.CREATIVE ? RSTiles.CREATIVE_PORTABLE_GRID : RSTiles.PORTABLE_GRID);
@@ -228,10 +228,7 @@ public class PortableGridTile extends BaseTile implements ITickableTileEntity, I
 
         this.loadStorage();
 
-        onTick.add(() -> {
-            active = isGridActive();
-            diskState = getDiskState();
-        });
+        loadNextTick = true;
     }
 
     public void applyDataFromItemToTile(ItemStack stack) {
@@ -757,9 +754,10 @@ public class PortableGridTile extends BaseTile implements ITickableTileEntity, I
 
     @Override
     public void tick() {
-        if (!onTick.isEmpty()) {
-            onTick.forEach(Runnable::run);
-            onTick.clear();
+        if (loadNextTick) {
+            active = isGridActive();
+            diskState = getDiskState();
+            loadNextTick = false;
         }
     }
 }


### PR DESCRIPTION
fixes #2632 by delaying all checks until the first tick. 