### PR TITLE
[Server] Speed up chunk loading when many similar items in RS

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/api/util/IStackList.java
+++ b/src/main/java/com/refinedmods/refinedstorage/api/util/IStackList.java
@@ -76,15 +76,24 @@ public interface IStackList<T> {
     /**
      * Returns a stack.
      *
+     * {@code flags} is assumed to contain at least {@code COMPARE_NBT}, because
+     * otherwise there may be multiple candidates to return.
+     *
      * @param stack the stack to search for
      * @param flags the flags to compare on, see {@link IComparer}
      * @return the stack, or null if no stack was found
      */
     @Nullable
-    T get(@Nonnull T stack, int flags);
+    default T get(@Nonnull T stack, int flags) {
+        StackListEntry<T> entry = getEntry(stack, flags);
+        return entry == null ? null : entry.getStack();
+    }
 
     /**
      * Returns a stack entry.
+     *
+     * {@code flags} is assumed to contain at least {@code COMPARE_NBT}, because
+     * otherwise there may be multiple candidates to return.
      *
      * @param stack the stack to search for
      * @param flags the flags to compare on, see {@link IComparer}

--- a/src/main/java/com/refinedmods/refinedstorage/api/util/IStackList.java
+++ b/src/main/java/com/refinedmods/refinedstorage/api/util/IStackList.java
@@ -76,9 +76,6 @@ public interface IStackList<T> {
     /**
      * Returns a stack.
      *
-     * {@code flags} is assumed to contain at least {@code COMPARE_NBT}, because
-     * otherwise there may be multiple candidates to return.
-     *
      * @param stack the stack to search for
      * @param flags the flags to compare on, see {@link IComparer}
      * @return the stack, or null if no stack was found
@@ -91,9 +88,6 @@ public interface IStackList<T> {
 
     /**
      * Returns a stack entry.
-     *
-     * {@code flags} is assumed to contain at least {@code COMPARE_NBT}, because
-     * otherwise there may be multiple candidates to return.
      *
      * @param stack the stack to search for
      * @param flags the flags to compare on, see {@link IComparer}

--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/util/FluidStackList.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/util/FluidStackList.java
@@ -92,20 +92,6 @@ public class FluidStackList implements IStackList<FluidStack> {
         return found.getAmount();
     }
 
-    @Override
-    @Nullable
-    public FluidStack get(@Nonnull FluidStack stack, int flags) {
-        for (StackListEntry<FluidStack> entry : stacks.get(stack.getFluid())) {
-            FluidStack otherStack = entry.getStack();
-
-            if (API.instance().getComparer().isEqual(otherStack, stack, flags)) {
-                return otherStack;
-            }
-        }
-
-        return null;
-    }
-
     @Nullable
     @Override
     public StackListEntry<FluidStack> getEntry(@Nonnull FluidStack stack, int flags) {


### PR DESCRIPTION
> When there are similar items (same type, different enchantments and
damage) in an RS system, it can sometimes take a very long time to load.
> 
> This should take a stab at fixing that, with the caveat that it
potentially reduces the flexibility of `IStackList#get` and
`IStackList#getEntry` (now forces at least COMPARE_NBT, though as far as
I can tell there was never a time when this wasn't the case already).

When creating a system saturated with junk for #2705, I ran into the problem that my singleplayer world was taking a while to load (about 1m 17s by the end of it). Here's something that takes that same world down to 12s from first click to landing in the world.

The junk tested with was fishing "treasure", so a lot of bows, fishing rods, and enchanted books. The fishing rods and bows all have varying damage levels, and everything has varying enchantments.