### PR TITLE
2-way JEI sync on search boxes

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/api/network/grid/IGrid.java
+++ b/src/main/java/com/refinedmods/refinedstorage/api/network/grid/IGrid.java
@@ -36,6 +36,8 @@ public interface IGrid {
     int SEARCH_BOX_MODE_NORMAL_AUTOSELECTED = 1;
     int SEARCH_BOX_MODE_JEI_SYNCHRONIZED = 2;
     int SEARCH_BOX_MODE_JEI_SYNCHRONIZED_AUTOSELECTED = 3;
+    int SEARCH_BOX_MODE_JEI_SYNCHRONIZED_2WAY = 4;
+    int SEARCH_BOX_MODE_JEI_SYNCHRONIZED_2WAY_AUTOSELECTED = 5;
 
     int VIEW_TYPE_NORMAL = 0;
     int VIEW_TYPE_NON_CRAFTABLES = 1;
@@ -255,11 +257,22 @@ public interface IGrid {
         return mode == SEARCH_BOX_MODE_NORMAL ||
             mode == SEARCH_BOX_MODE_NORMAL_AUTOSELECTED ||
             mode == SEARCH_BOX_MODE_JEI_SYNCHRONIZED ||
-            mode == SEARCH_BOX_MODE_JEI_SYNCHRONIZED_AUTOSELECTED;
+            mode == SEARCH_BOX_MODE_JEI_SYNCHRONIZED_AUTOSELECTED ||
+            mode == SEARCH_BOX_MODE_JEI_SYNCHRONIZED_2WAY ||
+            mode == SEARCH_BOX_MODE_JEI_SYNCHRONIZED_2WAY_AUTOSELECTED;
     }
 
     static boolean isSearchBoxModeWithAutoselection(int mode) {
-        return mode == SEARCH_BOX_MODE_NORMAL_AUTOSELECTED || mode == SEARCH_BOX_MODE_JEI_SYNCHRONIZED_AUTOSELECTED;
+        return mode == SEARCH_BOX_MODE_NORMAL_AUTOSELECTED ||
+            mode == SEARCH_BOX_MODE_JEI_SYNCHRONIZED_AUTOSELECTED ||
+            mode == SEARCH_BOX_MODE_JEI_SYNCHRONIZED_2WAY_AUTOSELECTED;
+    }
+
+    static boolean doesSearchBoxModeUseJEI(int mode) {
+        return mode == SEARCH_BOX_MODE_JEI_SYNCHRONIZED ||
+            mode == SEARCH_BOX_MODE_JEI_SYNCHRONIZED_AUTOSELECTED ||
+            mode == SEARCH_BOX_MODE_JEI_SYNCHRONIZED_2WAY ||
+            mode == SEARCH_BOX_MODE_JEI_SYNCHRONIZED_2WAY_AUTOSELECTED;
     }
 
     static boolean isValidSortingType(int type) {

--- a/src/main/java/com/refinedmods/refinedstorage/screen/widget/SearchWidget.java
+++ b/src/main/java/com/refinedmods/refinedstorage/screen/widget/SearchWidget.java
@@ -1,5 +1,6 @@
 package com.refinedmods.refinedstorage.screen.widget;
 
+import com.mojang.blaze3d.matrix.MatrixStack;
 import com.refinedmods.refinedstorage.RSKeyBindings;
 import com.refinedmods.refinedstorage.api.network.grid.IGrid;
 import com.refinedmods.refinedstorage.integration.jei.JeiIntegration;
@@ -29,9 +30,14 @@ public class SearchWidget extends TextFieldWidget {
     }
 
     public void updateJei() {
-        if (JeiIntegration.isLoaded() && (mode == IGrid.SEARCH_BOX_MODE_JEI_SYNCHRONIZED || mode == IGrid.SEARCH_BOX_MODE_JEI_SYNCHRONIZED_AUTOSELECTED)) {
+        if (canSyncWithJEINow()) {
             RSJeiPlugin.getRuntime().getIngredientFilter().setFilterText(getText());
         }
+    }
+
+    private boolean canSyncWithJEINow() {
+        return (this.mode == IGrid.SEARCH_BOX_MODE_JEI_SYNCHRONIZED || this.mode == IGrid.SEARCH_BOX_MODE_JEI_SYNCHRONIZED_AUTOSELECTED)
+                && JeiIntegration.isLoaded();
     }
 
     @Override
@@ -148,5 +154,24 @@ public class SearchWidget extends TextFieldWidget {
 
         this.setCanLoseFocus(!IGrid.isSearchBoxModeWithAutoselection(mode));
         this.setFocused(IGrid.isSearchBoxModeWithAutoselection(mode));
+
+        if (canSyncWithJEINow()) {
+            setTextFromJEI();
+        }
+    }
+
+    private void setTextFromJEI() {
+        final String filterText = RSJeiPlugin.getRuntime().getIngredientFilter().getFilterText();
+        if (!getText().equals(filterText)) {
+            setText(filterText);
+        }
+    }
+
+    @Override
+    public void renderButton(MatrixStack p_230431_1_, int p_230431_2_, int p_230431_3_, float p_230431_4_) {
+        if (canSyncWithJEINow() && RSJeiPlugin.getRuntime().getIngredientListOverlay().hasKeyboardFocus()) {
+            setTextFromJEI();
+        }
+        super.renderButton(p_230431_1_, p_230431_2_, p_230431_3_, p_230431_4_);
     }
 }

--- a/src/main/java/com/refinedmods/refinedstorage/screen/widget/SearchWidget.java
+++ b/src/main/java/com/refinedmods/refinedstorage/screen/widget/SearchWidget.java
@@ -30,13 +30,18 @@ public class SearchWidget extends TextFieldWidget {
     }
 
     public void updateJei() {
-        if (canSyncWithJEINow()) {
+        if (canSyncToJEINow()) {
             RSJeiPlugin.getRuntime().getIngredientFilter().setFilterText(getText());
         }
     }
 
-    private boolean canSyncWithJEINow() {
-        return (this.mode == IGrid.SEARCH_BOX_MODE_JEI_SYNCHRONIZED || this.mode == IGrid.SEARCH_BOX_MODE_JEI_SYNCHRONIZED_AUTOSELECTED)
+    private boolean canSyncToJEINow() {
+        return IGrid.doesSearchBoxModeUseJEI(this.mode) && JeiIntegration.isLoaded();
+    }
+
+    private boolean canSyncFromJEINow() {
+        return (this.mode == IGrid.SEARCH_BOX_MODE_JEI_SYNCHRONIZED_2WAY ||
+                this.mode == IGrid.SEARCH_BOX_MODE_JEI_SYNCHRONIZED_2WAY_AUTOSELECTED)
                 && JeiIntegration.isLoaded();
     }
 
@@ -155,7 +160,7 @@ public class SearchWidget extends TextFieldWidget {
         this.setCanLoseFocus(!IGrid.isSearchBoxModeWithAutoselection(mode));
         this.setFocused(IGrid.isSearchBoxModeWithAutoselection(mode));
 
-        if (canSyncWithJEINow()) {
+        if (canSyncFromJEINow()) {
             setTextFromJEI();
         }
     }
@@ -169,7 +174,7 @@ public class SearchWidget extends TextFieldWidget {
 
     @Override
     public void renderButton(MatrixStack p_230431_1_, int p_230431_2_, int p_230431_3_, float p_230431_4_) {
-        if (canSyncWithJEINow() && RSJeiPlugin.getRuntime().getIngredientListOverlay().hasKeyboardFocus()) {
+        if (canSyncFromJEINow() && RSJeiPlugin.getRuntime().getIngredientListOverlay().hasKeyboardFocus()) {
             setTextFromJEI();
         }
         super.renderButton(p_230431_1_, p_230431_2_, p_230431_3_, p_230431_4_);

--- a/src/main/java/com/refinedmods/refinedstorage/screen/widget/sidebutton/CrafterManagerSearchBoxModeSideButton.java
+++ b/src/main/java/com/refinedmods/refinedstorage/screen/widget/sidebutton/CrafterManagerSearchBoxModeSideButton.java
@@ -1,49 +1,21 @@
 package com.refinedmods.refinedstorage.screen.widget.sidebutton;
 
-import com.mojang.blaze3d.matrix.MatrixStack;
-import com.refinedmods.refinedstorage.api.network.grid.IGrid;
-import com.refinedmods.refinedstorage.integration.jei.JeiIntegration;
 import com.refinedmods.refinedstorage.screen.CrafterManagerScreen;
 import com.refinedmods.refinedstorage.tile.CrafterManagerTile;
 import com.refinedmods.refinedstorage.tile.data.TileDataManager;
-import net.minecraft.client.resources.I18n;
-import net.minecraft.util.text.TextFormatting;
 
-public class CrafterManagerSearchBoxModeSideButton extends SideButton {
+public class CrafterManagerSearchBoxModeSideButton extends SearchBoxModeSideButton {
     public CrafterManagerSearchBoxModeSideButton(CrafterManagerScreen screen) {
         super(screen);
     }
 
     @Override
-    public String getTooltip() {
-        return I18n.format("sidebutton.refinedstorage.grid.search_box_mode") + "\n" + TextFormatting.GRAY + I18n.format("sidebutton.refinedstorage.grid.search_box_mode." + ((CrafterManagerScreen) screen).getCrafterManager().getSearchBoxMode());
+    protected int getSearchBoxMode() {
+        return ((CrafterManagerScreen) screen).getCrafterManager().getSearchBoxMode();
     }
 
     @Override
-    protected void renderButtonIcon(MatrixStack matrixStack, int x, int y) {
-        int mode = ((CrafterManagerScreen) screen).getCrafterManager().getSearchBoxMode();
-
-        screen.blit(matrixStack, x, y, mode == IGrid.SEARCH_BOX_MODE_NORMAL_AUTOSELECTED || mode == IGrid.SEARCH_BOX_MODE_JEI_SYNCHRONIZED_AUTOSELECTED ? 16 : 0, 96, 16, 16);
-    }
-
-    @Override
-    public void onPress() {
-        int mode = ((CrafterManagerScreen) screen).getCrafterManager().getSearchBoxMode();
-
-        if (mode == IGrid.SEARCH_BOX_MODE_NORMAL) {
-            mode = IGrid.SEARCH_BOX_MODE_NORMAL_AUTOSELECTED;
-        } else if (mode == IGrid.SEARCH_BOX_MODE_NORMAL_AUTOSELECTED) {
-            if (JeiIntegration.isLoaded()) {
-                mode = IGrid.SEARCH_BOX_MODE_JEI_SYNCHRONIZED;
-            } else {
-                mode = IGrid.SEARCH_BOX_MODE_NORMAL;
-            }
-        } else if (mode == IGrid.SEARCH_BOX_MODE_JEI_SYNCHRONIZED) {
-            mode = IGrid.SEARCH_BOX_MODE_JEI_SYNCHRONIZED_AUTOSELECTED;
-        } else if (mode == IGrid.SEARCH_BOX_MODE_JEI_SYNCHRONIZED_AUTOSELECTED) {
-            mode = IGrid.SEARCH_BOX_MODE_NORMAL;
-        }
-
+    protected void setSearchBoxMode(int mode) {
         TileDataManager.setParameter(CrafterManagerTile.SEARCH_BOX_MODE, mode);
     }
 }

--- a/src/main/java/com/refinedmods/refinedstorage/screen/widget/sidebutton/GridSearchBoxModeSideButton.java
+++ b/src/main/java/com/refinedmods/refinedstorage/screen/widget/sidebutton/GridSearchBoxModeSideButton.java
@@ -1,49 +1,20 @@
 package com.refinedmods.refinedstorage.screen.widget.sidebutton;
 
-import com.mojang.blaze3d.matrix.MatrixStack;
-import com.refinedmods.refinedstorage.api.network.grid.IGrid;
-import com.refinedmods.refinedstorage.integration.jei.JeiIntegration;
 import com.refinedmods.refinedstorage.screen.grid.GridScreen;
-import net.minecraft.client.resources.I18n;
-import net.minecraft.util.text.TextFormatting;
 
-public class GridSearchBoxModeSideButton extends SideButton {
+public class GridSearchBoxModeSideButton extends SearchBoxModeSideButton {
     public GridSearchBoxModeSideButton(GridScreen screen) {
         super(screen);
     }
 
     @Override
-    public String getTooltip() {
-        return I18n.format("sidebutton.refinedstorage.grid.search_box_mode") + "\n" + TextFormatting.GRAY + I18n.format("sidebutton.refinedstorage.grid.search_box_mode." + ((GridScreen) screen).getGrid().getSearchBoxMode());
+    protected int getSearchBoxMode() {
+        return ((GridScreen) screen).getGrid().getSearchBoxMode();
     }
 
     @Override
-    protected void renderButtonIcon(MatrixStack matrixStack, int x, int y) {
-        int mode = ((GridScreen) screen).getGrid().getSearchBoxMode();
-
-        screen.blit(matrixStack, x, y, mode == IGrid.SEARCH_BOX_MODE_NORMAL_AUTOSELECTED || mode == IGrid.SEARCH_BOX_MODE_JEI_SYNCHRONIZED_AUTOSELECTED ? 16 : 0, 96, 16, 16);
-    }
-
-    @Override
-    public void onPress() {
-        int mode = ((GridScreen) screen).getGrid().getSearchBoxMode();
-
-        if (mode == IGrid.SEARCH_BOX_MODE_NORMAL) {
-            mode = IGrid.SEARCH_BOX_MODE_NORMAL_AUTOSELECTED;
-        } else if (mode == IGrid.SEARCH_BOX_MODE_NORMAL_AUTOSELECTED) {
-            if (JeiIntegration.isLoaded()) {
-                mode = IGrid.SEARCH_BOX_MODE_JEI_SYNCHRONIZED;
-            } else {
-                mode = IGrid.SEARCH_BOX_MODE_NORMAL;
-            }
-        } else if (mode == IGrid.SEARCH_BOX_MODE_JEI_SYNCHRONIZED) {
-            mode = IGrid.SEARCH_BOX_MODE_JEI_SYNCHRONIZED_AUTOSELECTED;
-        } else if (mode == IGrid.SEARCH_BOX_MODE_JEI_SYNCHRONIZED_AUTOSELECTED) {
-            mode = IGrid.SEARCH_BOX_MODE_NORMAL;
-        }
-
+    protected void setSearchBoxMode(int mode) {
         ((GridScreen) screen).getGrid().onSearchBoxModeChanged(mode);
-
         ((GridScreen) screen).getSearchField().setMode(mode);
     }
 }

--- a/src/main/java/com/refinedmods/refinedstorage/screen/widget/sidebutton/SearchBoxModeSideButton.java
+++ b/src/main/java/com/refinedmods/refinedstorage/screen/widget/sidebutton/SearchBoxModeSideButton.java
@@ -1,0 +1,58 @@
+package com.refinedmods.refinedstorage.screen.widget.sidebutton;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+import com.refinedmods.refinedstorage.api.network.grid.IGrid;
+import com.refinedmods.refinedstorage.integration.jei.JeiIntegration;
+import com.refinedmods.refinedstorage.screen.BaseScreen;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.util.text.TextFormatting;
+
+import java.util.Arrays;
+import java.util.List;
+
+public abstract class SearchBoxModeSideButton extends SideButton {
+    private static final List<Integer> MODE_ROTATION = Arrays.asList(
+            IGrid.SEARCH_BOX_MODE_NORMAL,
+            IGrid.SEARCH_BOX_MODE_NORMAL_AUTOSELECTED,
+            IGrid.SEARCH_BOX_MODE_JEI_SYNCHRONIZED,
+            IGrid.SEARCH_BOX_MODE_JEI_SYNCHRONIZED_AUTOSELECTED,
+            IGrid.SEARCH_BOX_MODE_JEI_SYNCHRONIZED_2WAY,
+            IGrid.SEARCH_BOX_MODE_JEI_SYNCHRONIZED_2WAY_AUTOSELECTED,
+            IGrid.SEARCH_BOX_MODE_NORMAL
+    );
+
+    private static int nextMode(int oldMode) {
+        return MODE_ROTATION.get(MODE_ROTATION.indexOf(oldMode) + 1);
+    }
+
+    public SearchBoxModeSideButton(BaseScreen<?> screen) {
+        super(screen);
+    }
+
+    @Override
+    public String getTooltip() {
+        return I18n.format("sidebutton.refinedstorage.grid.search_box_mode") + "\n" + TextFormatting.GRAY + I18n.format("sidebutton.refinedstorage.grid.search_box_mode." + getSearchBoxMode());
+    }
+
+    @Override
+    protected void renderButtonIcon(MatrixStack matrixStack, int x, int y) {
+        int mode = getSearchBoxMode();
+
+        screen.blit(matrixStack, x, y, IGrid.isSearchBoxModeWithAutoselection(mode) ? 16 : 0, 96, 16, 16);
+    }
+
+    @Override
+    public void onPress() {
+        int mode = nextMode(getSearchBoxMode());
+
+        if (IGrid.doesSearchBoxModeUseJEI(mode) && !JeiIntegration.isLoaded()) {
+            mode = IGrid.SEARCH_BOX_MODE_NORMAL;
+        }
+
+        setSearchBoxMode(mode);
+    }
+
+    protected abstract int getSearchBoxMode();
+
+    protected abstract void setSearchBoxMode(int mode);
+}

--- a/src/main/resources/assets/refinedstorage/lang/en_us.json
+++ b/src/main/resources/assets/refinedstorage/lang/en_us.json
@@ -178,6 +178,8 @@
   "sidebutton.refinedstorage.grid.search_box_mode.1": "Normal (autoselected)",
   "sidebutton.refinedstorage.grid.search_box_mode.2": "JEI synchronized",
   "sidebutton.refinedstorage.grid.search_box_mode.3": "JEI synchronized (autoselected)",
+  "sidebutton.refinedstorage.grid.search_box_mode.4": "JEI synchronized (two-way)",
+  "sidebutton.refinedstorage.grid.search_box_mode.5": "JEI synchronized (two-way autoselected)",
   "sidebutton.refinedstorage.grid.size": "Size",
   "sidebutton.refinedstorage.grid.size.0": "Stretch",
   "sidebutton.refinedstorage.grid.size.1": "Small",


### PR DESCRIPTION
Lets you type in either search box (when JEI sync is on) and lets you use JEI's searchbox as a "memory" between closing and reopening the GUI.

If I had to guess, the feedback on this is probably going to be "needs toggleable option" and I'd be happy to add that if that's what you're aiming for.