### PR TITLE
add default processing state

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/autocrafting/task/v6/node/ProcessingNode.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/autocrafting/task/v6/node/ProcessingNode.java
@@ -32,7 +32,7 @@ public class ProcessingNode extends Node {
     private IStackList<ItemStack> itemsReceived = API.instance().createItemStackList();
     private IStackList<FluidStack> fluidsReceived = API.instance().createFluidStackList();
 
-    private ProcessingState state;
+    private ProcessingState state = ProcessingState.READY;
 
     private int quantityFinished;
 


### PR DESCRIPTION
The writeToNBT can cause an NPE when the game saves before running the first successful update. 


adding a default should fix that. 
