### PR TITLE
cache filled disks fixes #2771

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/disk/factory/ItemStorageDiskFactory.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/disk/factory/ItemStorageDiskFactory.java
@@ -39,6 +39,8 @@ public class ItemStorageDiskFactory implements IStorageDiskFactory<ItemStack> {
             }
         }
 
+        disk.updateItemCount();
+
         return disk;
     }
 


### PR DESCRIPTION
~100 filled disks and went from additional +140ms down to +2ms. 

Still not ideal but at least it's not that bad anymore.

Could still throttle the disk manipulator but that wouldn't affect normal insertion. 