### PR TITLE
fix blockupdates always invalidating storage fixes #2568 #2631

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/node/ExternalStorageNetworkNode.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/node/ExternalStorageNetworkNode.java
@@ -22,6 +22,7 @@ import com.refinedmods.refinedstorage.tile.ExternalStorageTile;
 import com.refinedmods.refinedstorage.tile.config.*;
 import com.refinedmods.refinedstorage.util.AccessTypeUtils;
 import com.refinedmods.refinedstorage.util.StackUtils;
+import net.minecraft.block.BlockState;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tileentity.TileEntity;
@@ -59,6 +60,7 @@ public class ExternalStorageNetworkNode extends NetworkNode implements IStorageP
     private int type = IType.ITEMS;
     private AccessType accessType = AccessType.INSERT_EXTRACT;
     private int networkTicks;
+    private BlockState connectedBlockState;
 
     private final List<IExternalStorage<ItemStack>> itemStorages = new CopyOnWriteArrayList<>();
     private final List<IExternalStorage<FluidStack>> fluidStorages = new CopyOnWriteArrayList<>();
@@ -201,6 +203,15 @@ public class ExternalStorageNetworkNode extends NetworkNode implements IStorageP
         if (network != null) {
             network.getItemStorageCache().sort();
             network.getFluidStorageCache().sort();
+        }
+    }
+
+    public void onConnectedBlockChanged(BlockState state) {
+        if (state.equals(connectedBlockState)) {
+            update();
+        } else {
+            connectedBlockState = state;
+            updateStorage(network, InvalidateCause.NEIGHBOR_CHANGED);
         }
     }
 

--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/node/ExternalStorageNetworkNode.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/node/ExternalStorageNetworkNode.java
@@ -90,6 +90,7 @@ public class ExternalStorageNetworkNode extends NetworkNode implements IStorageP
         if (canUpdate() && world.isBlockPresent(pos)) {
             if (networkTicks++ == 0) {
                 updateStorage(network, InvalidateCause.INITIAL_TICK_INVALIDATION);
+                connectedBlockState = world.getBlockState(pos.offset(getDirection()));
 
                 return;
             }

--- a/src/main/java/com/refinedmods/refinedstorage/block/ExternalStorageBlock.java
+++ b/src/main/java/com/refinedmods/refinedstorage/block/ExternalStorageBlock.java
@@ -1,7 +1,6 @@
 package com.refinedmods.refinedstorage.block;
 
 import com.refinedmods.refinedstorage.api.network.node.INetworkNode;
-import com.refinedmods.refinedstorage.api.storage.cache.InvalidateCause;
 import com.refinedmods.refinedstorage.apiimpl.network.node.ExternalStorageNetworkNode;
 import com.refinedmods.refinedstorage.block.shape.ShapeCache;
 import com.refinedmods.refinedstorage.container.ExternalStorageContainer;
@@ -123,7 +122,7 @@ public class ExternalStorageBlock extends CableBlock {
             if (node instanceof ExternalStorageNetworkNode &&
                 node.getNetwork() != null &&
                 fromPos.equals(pos.offset(((ExternalStorageNetworkNode) node).getDirection()))) {
-                ((ExternalStorageNetworkNode) node).updateStorage(node.getNetwork(), InvalidateCause.NEIGHBOR_CHANGED);
+                ((ExternalStorageNetworkNode) node).onConnectedBlockChanged(world.getBlockState(fromPos));
             }
         }
     }


### PR DESCRIPTION
This should fix issues with being unable to extract items from the grid. 
Hopeful this doesn't have any side effects but not can't really guarantee that. 

Can't really think of a case where this fails though. 