### PR TITLE
Add API to get full list of stacks for an item/fluid type.

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/api/util/IStackList.java
+++ b/src/main/java/com/refinedmods/refinedstorage/api/util/IStackList.java
@@ -119,6 +119,12 @@ public interface IStackList<T> {
     Collection<StackListEntry<T>> getStacks();
 
     /**
+     * @return a collection of stacks matching the given type (ignoring NBT)
+     */
+    @Nonnull
+    Collection<StackListEntry<T>> getStacks(@Nonnull T stack);
+
+    /**
      * @return a new copy of this list, with the stacks in it copied as well
      */
     @Nonnull

--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/util/FluidStackList.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/util/FluidStackList.java
@@ -6,14 +6,12 @@ import com.refinedmods.refinedstorage.api.util.StackListEntry;
 import com.refinedmods.refinedstorage.api.util.StackListResult;
 import com.refinedmods.refinedstorage.apiimpl.API;
 import net.minecraft.fluid.Fluid;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 public class FluidStackList implements IStackList<FluidStack> {
     private final ArrayListMultimap<Fluid, StackListEntry<FluidStack>> stacks = ArrayListMultimap.create();
@@ -141,6 +139,12 @@ public class FluidStackList implements IStackList<FluidStack> {
     @Override
     public Collection<StackListEntry<FluidStack>> getStacks() {
         return stacks.values();
+    }
+
+    @Override
+    @Nonnull
+    public Collection<StackListEntry<FluidStack>> getStacks(@Nonnull FluidStack stack) {
+        return stacks.get(stack.getFluid());
     }
 
     @Override

--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/util/ItemStackList.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/util/ItemStackList.java
@@ -11,10 +11,7 @@ import net.minecraftforge.items.ItemHandlerHelper;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 public class ItemStackList implements IStackList<ItemStack> {
     private final ArrayListMultimap<Item, StackListEntry<ItemStack>> stacks = ArrayListMultimap.create();
@@ -139,6 +136,12 @@ public class ItemStackList implements IStackList<ItemStack> {
     @Override
     public Collection<StackListEntry<ItemStack>> getStacks() {
         return stacks.values();
+    }
+
+    @Override
+    @Nonnull
+    public Collection<StackListEntry<ItemStack>> getStacks(@Nonnull ItemStack stack) {
+        return stacks.get(stack.getItem());
     }
 
     @Override


### PR DESCRIPTION
This adds an API method to allow fetching the complete list of stacks matching a given item type.

(The existing APIs only let you get a list of all stacks of all types [which is less efficient], or the first stack matching a given item/fluid name and NBT matching flags [which may be insufficient].)

The motivating case is to allow a more complex NBT comparison for an item by calling the new `getStacks(type)` (which is more efficient than calling `getStacks()` as it doesn't need to process many extraneous items on large storages), perform some custom logic to decide which of these stacks is the one desired (e.g. by evaluating the tags), and then use that stack in further operations (such as extracting it).

I considered an alternative implementation that returned only the `ItemStack`/`FluidStack` in the list rather than the full entry, but (a) providing the UUID might enable using `get(uuid)` to try a faster lookup later on, and (b) this way seemed more efficient since it doesn't require creating a new collection.