### PR TITLE
Fix loading not working on new worlds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Refined Storage Changelog
 
+### 1.9.11
+
+- Fixed Disks and Nodes not loading when they did not previously exist
+- If you are affected by this please go to the world/data/ folder and remove the ".temp" ending from the files before
+  launching
+
 ### 1.9.10
 
 - Improve performance of the Grid view (ScoreUnder)

--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/util/RSWorldSavedData.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/util/RSWorldSavedData.java
@@ -36,9 +36,15 @@ public abstract class RSWorldSavedData extends WorldSavedData {
 
             try {
                 CompressedStreamTools.func_244264_a(compoundnbt, tempFile);
-                if (fileIn.delete()) {
-                    tempFile.renameTo(fileIn);
+                if (fileIn.exists()) {
+                    if (!fileIn.delete()) {
+                        LOGGER.error("Failed To delete " + fileIn.getName());
+                    }
                 }
+                if (!tempFile.renameTo(fileIn)) {
+                    LOGGER.error("Failed to rename " + tempFile.getName());
+                }
+
             } catch (IOException ioexception) {
                 LOGGER.error("Could not save data {}", this, ioexception);
             }


### PR DESCRIPTION
The issue happens when there is no disk file present. The deletion fails and as such the temp file will not be renamed. 

Fixed that and also added some logging. 

Not sure if changelog is the right place to put the instructions. 