### PR TITLE
Crash #2811 fix

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/screen/grid/view/GridViewImpl.java
+++ b/src/main/java/com/refinedmods/refinedstorage/screen/grid/view/GridViewImpl.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 public class GridViewImpl implements IGridView {
     private final GridScreen screen;
     private boolean canCraft;
+    private boolean active = false;
 
     private final IGridSorter defaultSorter;
     private final List<IGridSorter> sorters;
@@ -56,8 +57,10 @@ public class GridViewImpl implements IGridView {
                     .filter(getActiveFilters())
                     .sorted(getActiveSort())
                     .collect(Collectors.toList());
+            this.active = true;
         } else {
             this.stacks = new ArrayList<>();
+            this.active = false;
         }
 
         this.screen.updateScrollbar();
@@ -111,6 +114,9 @@ public class GridViewImpl implements IGridView {
 
     @Override
     public void postChange(IGridStack stack, int delta) {
+        if (!this.active) {
+            return;
+        }
         // COMMENT 1 (about this if check in general)
         // Update the other id reference if needed.
         // Taking a stack out - and then re-inserting it - gives the new stack a new ID

--- a/src/main/java/com/refinedmods/refinedstorage/screen/grid/view/GridViewImpl.java
+++ b/src/main/java/com/refinedmods/refinedstorage/screen/grid/view/GridViewImpl.java
@@ -57,7 +57,7 @@ public class GridViewImpl implements IGridView {
                     .sorted(getActiveSort())
                     .collect(Collectors.toList());
         } else {
-            this.stacks = Collections.emptyList();
+            this.stacks = new ArrayList<>();
         }
 
         this.screen.updateScrollbar();

--- a/src/main/java/com/refinedmods/refinedstorage/screen/grid/view/GridViewImpl.java
+++ b/src/main/java/com/refinedmods/refinedstorage/screen/grid/view/GridViewImpl.java
@@ -56,7 +56,7 @@ public class GridViewImpl implements IGridView {
             this.stacks = map.values().stream()
                     .filter(getActiveFilters())
                     .sorted(getActiveSort())
-                    .collect(Collectors.toList());
+                    .collect(Collectors.toCollection(ArrayList::new));
             this.active = true;
         } else {
             this.stacks = new ArrayList<>();


### PR DESCRIPTION
Only the first commit is necessary to avoid the crash. The second is to avoid updating the inventory when it shouldn't, and the third is to safeguard against technically-non-breaking Java implementation changes.

→#2811