### PR TITLE
fix allowed tags for fluid outputs

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/network/SetFluidFilterSlotMessage.java
+++ b/src/main/java/com/refinedmods/refinedstorage/network/SetFluidFilterSlotMessage.java
@@ -62,7 +62,7 @@ public class SetFluidFilterSlotMessage {
             // Prevent the grid crafting matrix inventory listener from resetting the list.
             if (container instanceof GridContainer) {
                 IGrid grid = ((GridContainer) container).getGrid();
-                if (grid instanceof GridNetworkNode) {
+                if (grid instanceof GridNetworkNode && slot.getSlotIndex() < ((GridNetworkNode) grid).getAllowedTagList().getAllowedFluidTags().size()) {
                     Set<ResourceLocation> list = new HashSet<>(((GridNetworkNode) grid).getAllowedTagList().getAllowedFluidTags().get(slot.getSlotIndex()));
 
                     postAction = () -> {


### PR DESCRIPTION
Same as #2785. But for fluids. 