### PR TITLE
fix grid search not working for industrial foregoing

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/screen/grid/stack/ItemGridStack.java
+++ b/src/main/java/com/refinedmods/refinedstorage/screen/grid/stack/ItemGridStack.java
@@ -112,7 +112,7 @@ public class ItemGridStack implements IGridStack {
                 cachedModId = ERROR_PLACEHOLDER;
             }
 
-            cachedModId = cachedModId.toLowerCase(Locale.ROOT);
+            cachedModId = cachedModId.toLowerCase();
         }
 
         return cachedModId;

--- a/src/main/java/com/refinedmods/refinedstorage/screen/grid/stack/ItemGridStack.java
+++ b/src/main/java/com/refinedmods/refinedstorage/screen/grid/stack/ItemGridStack.java
@@ -112,7 +112,7 @@ public class ItemGridStack implements IGridStack {
                 cachedModId = ERROR_PLACEHOLDER;
             }
 
-            cachedModId = cachedModId.toLowerCase();
+            cachedModId = cachedModId.toLowerCase().replace(" ", "");
         }
 
         return cachedModId;

--- a/src/main/java/com/refinedmods/refinedstorage/screen/grid/stack/ItemGridStack.java
+++ b/src/main/java/com/refinedmods/refinedstorage/screen/grid/stack/ItemGridStack.java
@@ -111,6 +111,8 @@ public class ItemGridStack implements IGridStack {
             if (cachedModId == null) {
                 cachedModId = ERROR_PLACEHOLDER;
             }
+
+            cachedModId = cachedModId.toLowerCase(Locale.ROOT);
         }
 
         return cachedModId;


### PR DESCRIPTION
Buuz is doing some sillyness returning a pretty mod name for `getCreatorModId`. Presumable to make them appear this way in JEI. 

Applying the same parser to the mod id as to the grid string should make these cases no longer an issue. 