### PR TITLE
Fix flickering issue with storage monitors.

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/render/tesr/StorageMonitorTileRenderer.java
+++ b/src/main/java/com/refinedmods/refinedstorage/render/tesr/StorageMonitorTileRenderer.java
@@ -71,9 +71,9 @@ public class StorageMonitorTileRenderer extends TileEntityRenderer<StorageMonito
 
         matrixStack.translate(0.5D, 0.5D, 0.5D);
         matrixStack.translate(
-            ((float) direction.getXOffset() * 0.5F) + (direction.getZOffset() * stringOffset),
+            ((float) direction.getXOffset() * 0.501F) + (direction.getZOffset() * stringOffset),
             -0.275,
-            ((float) direction.getZOffset() * 0.5F) - (direction.getXOffset() * stringOffset)
+            ((float) direction.getZOffset() * 0.501F) - (direction.getXOffset() * stringOffset)
         );
 
         matrixStack.rotate(TransformationHelper.quatFromXYZ(new Vector3f(direction.getXOffset() * 180, 0, direction.getZOffset() * 180), true));


### PR DESCRIPTION
This PR will add a *tiny* little offset to the position of the text, getting rid of the z-fighting. This fixes issue #2768.

Note: The text will be offset both in X and Z direction and does not care about the actual orientation of the block. I'm unfortunately not well versed enough with forge to figure out which side is the front. However, the difference is so minuscule that it shouldn't be noticeable.