### PR TITLE
Fix craftable stack vanishing or duplicating when using craftable view

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/screen/grid/view/GridViewImpl.java
+++ b/src/main/java/com/refinedmods/refinedstorage/screen/grid/view/GridViewImpl.java
@@ -144,6 +144,7 @@ public class GridViewImpl implements IGridView {
         IGridStack existing = map.get(stack.getId());
         boolean stillExists = true;
         boolean shouldSort = screen.canSort();
+        boolean shouldDisplay = getActiveFilters().test(existing);
 
         if (existing == null) {
             stack.setQuantity(delta);
@@ -151,7 +152,7 @@ public class GridViewImpl implements IGridView {
             map.put(stack.getId(), stack);
             existing = stack;
 
-            if (craftingStack != null && shouldSort) {
+            if (craftingStack != null && shouldSort && shouldDisplay) {
                 stacks.remove(craftingStack);
             }
         } else {
@@ -163,7 +164,7 @@ public class GridViewImpl implements IGridView {
                 map.remove(existing.getId());
                 stillExists = false;
 
-                if (craftingStack != null && shouldSort && getActiveFilters().test(craftingStack)) {
+                if (craftingStack != null && shouldSort && shouldDisplay && getActiveFilters().test(craftingStack)) {
                     addStack(craftingStack);
                 }
             }
@@ -172,7 +173,7 @@ public class GridViewImpl implements IGridView {
         }
 
         if (shouldSort) {
-            if (stillExists && getActiveFilters().test(existing)) {
+            if (stillExists && shouldDisplay) {
                 addStack(existing);
             }
             this.screen.updateScrollbar();


### PR DESCRIPTION
Fixes #2934.

Occured when using the craftable view and an associated non-craftable stack was:
- Fully removed, the craftable stack duplicated.
- Newly added, the craftable stack vanished.

Noticed that the craftable view in 1.12.2 was slightly different. It also also had the non-craftable stack if there was a craftable one associated with it. In 1.16.5 the craftable view shows only the craftable stack alone (which matches what AE2's craftable view does).

I think this is intended though? So I left the craftable view's predicate untouched.

However, the changes in this PR are general enough to work even if any view's predicate is updated.