### PR TITLE
Calculate vertex data step size in FullbrightBakedModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Refined Storage Changelog
 
+### 1.9.13
+
+- Calculate vertex data step size in FullbrightBakedModel (ylou)
+
 ### 1.9.12
 
 - Fixed some issues when using the Grid when it's offline (Darkere)

--- a/src/main/java/com/refinedmods/refinedstorage/render/model/FullbrightBakedModel.java
+++ b/src/main/java/com/refinedmods/refinedstorage/render/model/FullbrightBakedModel.java
@@ -67,12 +67,13 @@ public class FullbrightBakedModel extends DelegateBakedModel {
 
     private static BakedQuad transformQuad(BakedQuad quad) {
         int[] vertexData = quad.getVertexData().clone();
+        int step = vertexData.length / 4;
 
         // Set lighting to fullbright on all vertices
         vertexData[6] = 0x00F000F0;
-        vertexData[6 + 8] = 0x00F000F0;
-        vertexData[6 + 8 + 8] = 0x00F000F0;
-        vertexData[6 + 8 + 8 + 8] = 0x00F000F0;
+        vertexData[6 + step] = 0x00F000F0;
+        vertexData[6 + 2 * step] = 0x00F000F0;
+        vertexData[6 + 3 * step] = 0x00F000F0;
 
         return new BakedQuad(
             vertexData,


### PR DESCRIPTION
Fixes #2919.

Texture glitches due to writing at fixed vertex data offsets. Straightforward fix on the optifine tracker pointed out by telemenar.

