### PR TITLE
Fix NPE in external storage when IFluidHandler goes away

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/FluidExternalStorage.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/FluidExternalStorage.java
@@ -83,8 +83,11 @@ public class FluidExternalStorage implements IExternalStorage<FluidStack> {
             return stack;
         }
 
-        if (context.acceptsFluid(stack)) {
-            int filled = handlerSupplier.get().fill(StackUtils.copy(stack, size), action == Action.PERFORM ? IFluidHandler.FluidAction.EXECUTE : IFluidHandler.FluidAction.SIMULATE);
+        IFluidHandler handler = handlerSupplier.get();
+
+        if (context.acceptsFluid(stack) && handler != null) {
+
+            int filled = handler.fill(StackUtils.copy(stack, size), action == Action.PERFORM ? IFluidHandler.FluidAction.EXECUTE : IFluidHandler.FluidAction.SIMULATE);
 
             if (filled == size) {
                 return FluidStack.EMPTY;


### PR DESCRIPTION
Fixes #2744. This bug happens when a tile with a FluidHandler capability invalidates it while RS is attempting to insert.

To reproduce:

1. Dock with T7 Tank (from /tank/null), with external storage bus attached. 
1. While inserting a fluid into the dock, remove the tank from the dock.

![2021-04-24_22 12 56](https://user-images.githubusercontent.com/7946299/115978487-ba348100-a54d-11eb-8dd6-1d1a15571d29.png)
