### PR TITLE
JEI transfer picks the most common ingredient

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/grid/CraftingGridBehavior.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/grid/CraftingGridBehavior.java
@@ -1,6 +1,7 @@
 package com.refinedmods.refinedstorage.apiimpl.network.grid;
 
 import com.refinedmods.refinedstorage.api.autocrafting.ICraftingPattern;
+import com.refinedmods.refinedstorage.api.autocrafting.ICraftingPatternProvider;
 import com.refinedmods.refinedstorage.api.network.INetwork;
 import com.refinedmods.refinedstorage.api.network.grid.GridType;
 import com.refinedmods.refinedstorage.api.network.grid.ICraftingGridBehavior;
@@ -286,7 +287,7 @@ public class CraftingGridBehavior implements ICraftingGridBehavior {
         for (int j = 0; j < player.inventory.getSizeInventory(); j++) {
             ItemStack inventoryStack = player.inventory.getStackInSlot(j);
 
-            if (inventoryStack.getItem() instanceof PatternItem) {
+            if (inventoryStack.getItem() instanceof ICraftingPatternProvider) {
                 ICraftingPattern pattern = PatternItem.fromCache(network.getWorld(), inventoryStack);
                 if (pattern.isValid()) {
                     for (ItemStack stack : pattern.getOutputs()) {

--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/grid/CraftingGridBehavior.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/grid/CraftingGridBehavior.java
@@ -195,9 +195,12 @@ public class CraftingGridBehavior implements ICraftingGridBehavior {
             if (recipe[i] != null) {
                 ItemStack[] possibilities = recipe[i];
 
-                if (network != null && grid.isGridActive()) {
+                if (network != null && grid.isGridActive() && network.getItemStorageCache() != null) {
                     // sort by the number of items in storage
-                    Arrays.sort(possibilities, Comparator.comparingInt((ItemStack a) -> network.extractItem(a, Integer.MAX_VALUE, IComparer.COMPARE_NBT, Action.SIMULATE).getCount()).reversed());
+                    Arrays.sort(possibilities, Comparator.comparingInt((ItemStack a) -> {
+                        ItemStack stack = network.getItemStorageCache().getList().get(a);
+                        return stack == null ? 0 : stack.getCount();
+                    }).reversed());
                 }
 
                 // If we are a crafting grid

--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/grid/CraftingGridBehavior.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/grid/CraftingGridBehavior.java
@@ -10,9 +10,11 @@ import com.refinedmods.refinedstorage.api.util.IComparer;
 import com.refinedmods.refinedstorage.api.util.IStackList;
 import com.refinedmods.refinedstorage.apiimpl.API;
 import com.refinedmods.refinedstorage.apiimpl.network.node.GridNetworkNode;
+import com.refinedmods.refinedstorage.item.PatternItem;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.CraftingInventory;
 import net.minecraft.inventory.InventoryHelper;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.ICraftingRecipe;
 import net.minecraft.util.NonNullList;
@@ -21,10 +23,9 @@ import net.minecraftforge.fml.hooks.BasicEventHooks;
 import net.minecraftforge.items.ItemHandlerHelper;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class CraftingGridBehavior implements ICraftingGridBehavior {
     @Override
@@ -190,17 +191,16 @@ public class CraftingGridBehavior implements ICraftingGridBehavior {
             }
         }
 
+        AtomicReference<Map<Item, ItemStack>> playerItems = new AtomicReference<>();
         // Now let's fill the matrix
         for (int i = 0; i < grid.getCraftingMatrix().getSizeInventory(); ++i) {
             if (recipe[i] != null) {
                 ItemStack[] possibilities = recipe[i];
 
                 if (network != null && grid.isGridActive() && network.getItemStorageCache() != null) {
-                    // sort by the number of items in storage
-                    Arrays.sort(possibilities, Comparator.comparingInt((ItemStack a) -> {
-                        ItemStack stack = network.getItemStorageCache().getList().get(a);
-                        return stack == null ? 0 : stack.getCount();
-                    }).reversed());
+
+                    // sort by the number of items in storage, craftables and inventory
+                    Arrays.sort(possibilities, compareByItemStackCounts(player, network, playerItems));
                 }
 
                 // If we are a crafting grid
@@ -256,4 +256,52 @@ public class CraftingGridBehavior implements ICraftingGridBehavior {
             ((GridNetworkNode) grid).markDirty();
         }
     }
+
+    private Comparator<ItemStack> compareByItemStackCounts(PlayerEntity player, INetwork network, AtomicReference<Map<Item, ItemStack>> playerItems) {
+        AtomicInteger s = new AtomicInteger();
+        return Comparator.comparingInt((ItemStack itemStack) -> {
+
+            ItemStack stack = network.getItemStorageCache().getList().get(itemStack);
+            if (stack != null) {
+                return stack.getCount();
+            }
+
+            if (network.getCraftingManager().getPattern(itemStack) != null) {
+                return 1;
+            }
+
+            if (playerItems.get() == null) {
+                playerItems.set(makePlayerInventoryMap(player, network));
+            } else {
+                System.out.println(s.incrementAndGet());
+            }
+
+            ItemStack onPlayer = playerItems.get().get(itemStack.getItem());
+            if (onPlayer != null) {
+                return onPlayer.getCount();
+            }
+            return 0;
+        }).reversed();
+    }
+
+    private Map<Item, ItemStack> makePlayerInventoryMap(PlayerEntity player, INetwork network) {
+        Map<Item, ItemStack> playerItems = new HashMap<>();
+        for (int j = 0; j < player.inventory.getSizeInventory(); j++) {
+            ItemStack inventoryStack = player.inventory.getStackInSlot(j);
+
+            if (inventoryStack.getItem() instanceof PatternItem) {
+                NonNullList<ItemStack> patternOutput = PatternItem.fromCache(network.getWorld(), inventoryStack).getOutputs();
+                for (ItemStack stack : patternOutput) {
+                    if (!stack.isEmpty()) {
+                        playerItems.put(stack.getItem(), stack);
+                    }
+                }
+            } else {
+                playerItems.put(inventoryStack.getItem(), inventoryStack);
+            }
+        }
+
+        return playerItems;
+    }
+
 }

--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/grid/CraftingGridBehavior.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/grid/CraftingGridBehavior.java
@@ -22,6 +22,8 @@ import net.minecraftforge.items.ItemHandlerHelper;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 
 public class CraftingGridBehavior implements ICraftingGridBehavior {
@@ -192,6 +194,11 @@ public class CraftingGridBehavior implements ICraftingGridBehavior {
         for (int i = 0; i < grid.getCraftingMatrix().getSizeInventory(); ++i) {
             if (recipe[i] != null) {
                 ItemStack[] possibilities = recipe[i];
+
+                if (network != null && grid.isGridActive()) {
+                    // sort by the number of items in storage
+                    Arrays.sort(possibilities, Comparator.comparingInt((ItemStack a) -> network.extractItem(a, Integer.MAX_VALUE, IComparer.COMPARE_NBT, Action.SIMULATE).getCount()).reversed());
+                }
 
                 // If we are a crafting grid
                 if (grid.getGridType() == GridType.CRAFTING) {

--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/grid/CraftingGridBehavior.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/grid/CraftingGridBehavior.java
@@ -1,5 +1,6 @@
 package com.refinedmods.refinedstorage.apiimpl.network.grid;
 
+import com.refinedmods.refinedstorage.api.autocrafting.ICraftingPattern;
 import com.refinedmods.refinedstorage.api.network.INetwork;
 import com.refinedmods.refinedstorage.api.network.grid.GridType;
 import com.refinedmods.refinedstorage.api.network.grid.ICraftingGridBehavior;
@@ -24,7 +25,6 @@ import net.minecraftforge.items.ItemHandlerHelper;
 
 import javax.annotation.Nullable;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class CraftingGridBehavior implements ICraftingGridBehavior {
@@ -258,7 +258,6 @@ public class CraftingGridBehavior implements ICraftingGridBehavior {
     }
 
     private Comparator<ItemStack> compareByItemStackCounts(PlayerEntity player, INetwork network, AtomicReference<Map<Item, ItemStack>> playerItems) {
-        AtomicInteger s = new AtomicInteger();
         return Comparator.comparingInt((ItemStack itemStack) -> {
 
             ItemStack stack = network.getItemStorageCache().getList().get(itemStack);
@@ -272,8 +271,6 @@ public class CraftingGridBehavior implements ICraftingGridBehavior {
 
             if (playerItems.get() == null) {
                 playerItems.set(makePlayerInventoryMap(player, network));
-            } else {
-                System.out.println(s.incrementAndGet());
             }
 
             ItemStack onPlayer = playerItems.get().get(itemStack.getItem());
@@ -290,10 +287,12 @@ public class CraftingGridBehavior implements ICraftingGridBehavior {
             ItemStack inventoryStack = player.inventory.getStackInSlot(j);
 
             if (inventoryStack.getItem() instanceof PatternItem) {
-                NonNullList<ItemStack> patternOutput = PatternItem.fromCache(network.getWorld(), inventoryStack).getOutputs();
-                for (ItemStack stack : patternOutput) {
-                    if (!stack.isEmpty()) {
-                        playerItems.put(stack.getItem(), stack);
+                ICraftingPattern pattern = PatternItem.fromCache(network.getWorld(), inventoryStack);
+                if (pattern.isValid()) {
+                    for (ItemStack stack : pattern.getOutputs()) {
+                        if (!stack.isEmpty()) {
+                            playerItems.put(stack.getItem(), stack);
+                        }
                     }
                 }
             } else {

--- a/src/main/java/com/refinedmods/refinedstorage/integration/jei/GridRecipeTransferHandler.java
+++ b/src/main/java/com/refinedmods/refinedstorage/integration/jei/GridRecipeTransferHandler.java
@@ -59,7 +59,7 @@ public class GridRecipeTransferHandler implements IRecipeTransferHandler<GridCon
     }
 
     private RecipeTransferCraftingGridError transferRecipeForCraftingGrid(GridContainer container, IRecipeLayout recipeLayout, PlayerEntity player, boolean doTransfer) {
-        IngredientTracker tracker = createTracker(container, recipeLayout, player);
+        IngredientTracker tracker = createTracker(container, recipeLayout, player, doTransfer);
 
         if (doTransfer) {
             if (tracker.hasMissingButAutocraftingAvailable() && Screen.hasControlDown()) {
@@ -84,7 +84,7 @@ public class GridRecipeTransferHandler implements IRecipeTransferHandler<GridCon
     }
 
     private IRecipeTransferError transferRecipeForPatternGrid(GridContainer container, IRecipeLayout recipeLayout, PlayerEntity player, boolean doTransfer) {
-        IngredientTracker tracker = createTracker(container, recipeLayout, player);
+        IngredientTracker tracker = createTracker(container, recipeLayout, player, doTransfer);
 
         if (doTransfer) {
             moveItems(container, recipeLayout, tracker);
@@ -97,8 +97,8 @@ public class GridRecipeTransferHandler implements IRecipeTransferHandler<GridCon
         return null;
     }
 
-    private IngredientTracker createTracker(GridContainer container, IRecipeLayout recipeLayout, PlayerEntity player) {
-        IngredientTracker tracker = new IngredientTracker(recipeLayout);
+    private IngredientTracker createTracker(GridContainer container, IRecipeLayout recipeLayout, PlayerEntity player, boolean doTransfer) {
+        IngredientTracker tracker = new IngredientTracker(recipeLayout, doTransfer);
 
         // Using IGridView#getStacks will return a *filtered* list of items in the view,
         // which will cause problems - especially if the user uses JEI synchronised searching.

--- a/src/main/java/com/refinedmods/refinedstorage/integration/jei/IngredientTracker.java
+++ b/src/main/java/com/refinedmods/refinedstorage/integration/jei/IngredientTracker.java
@@ -6,7 +6,9 @@ import com.refinedmods.refinedstorage.item.PatternItem;
 import com.refinedmods.refinedstorage.screen.grid.stack.IGridStack;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.gui.ingredient.IGuiIngredient;
+import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 
 import javax.annotation.Nullable;
@@ -31,8 +33,10 @@ public class IngredientTracker {
     public void addAvailableStack(ItemStack stack, @Nullable IGridStack gridStack) {
         int available = stack.getCount();
         if (stack.getItem() instanceof PatternItem) {
-            ItemStack outputStack = PatternItem.getOutputSlot(stack, 0);
-            storedItems.merge(outputStack.getItem().getRegistryName(), available, Integer::sum);
+            NonNullList<ItemStack> outputStacks = PatternItem.fromCache(Minecraft.getInstance().world,stack).getOutputs();
+            for (ItemStack outputStack : outputStacks) {
+                storedItems.merge(outputStack.getItem().getRegistryName(), outputStack.getCount(), Integer::sum);
+            }
         } else {
             storedItems.merge(stack.getItem().getRegistryName(), available, Integer::sum);
         }

--- a/src/main/java/com/refinedmods/refinedstorage/integration/jei/IngredientTracker.java
+++ b/src/main/java/com/refinedmods/refinedstorage/integration/jei/IngredientTracker.java
@@ -6,12 +6,14 @@ import com.refinedmods.refinedstorage.screen.grid.stack.IGridStack;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.gui.ingredient.IGuiIngredient;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
 
 import javax.annotation.Nullable;
 import java.util.*;
 
 public class IngredientTracker {
     private final List<Ingredient> ingredients = new ArrayList<>();
+    private final Map<ResourceLocation, Integer> storedItems = new HashMap<>();
 
     public IngredientTracker(IRecipeLayout recipeLayout) {
         for (IGuiIngredient<ItemStack> guiIngredient : recipeLayout.getItemStacks().getGuiIngredients().values()) {
@@ -27,6 +29,7 @@ public class IngredientTracker {
 
     public void addAvailableStack(ItemStack stack, @Nullable IGridStack gridStack) {
         int available = stack.getCount();
+        storedItems.merge(stack.getItem().getRegistryName(), available, Integer::sum);
 
         for (Ingredient ingredient : ingredients) {
             if (available == 0) {
@@ -77,5 +80,20 @@ public class IngredientTracker {
         }
 
         return toRequest;
+    }
+
+    public ItemStack findBestMatch(List<ItemStack> list) {
+        ItemStack stack = ItemStack.EMPTY;
+        int count = 0;
+
+        for (ItemStack itemStack : list) {
+            Integer stored = storedItems.get(itemStack.getItem().getRegistryName());
+            if (stored != null && stored > count) {
+                stack = itemStack;
+                count = stored;
+            }
+        }
+
+        return stack;
     }
 }

--- a/src/main/java/com/refinedmods/refinedstorage/integration/jei/IngredientTracker.java
+++ b/src/main/java/com/refinedmods/refinedstorage/integration/jei/IngredientTracker.java
@@ -1,6 +1,7 @@
 package com.refinedmods.refinedstorage.integration.jei;
 
 import com.refinedmods.refinedstorage.api.autocrafting.ICraftingPattern;
+import com.refinedmods.refinedstorage.api.autocrafting.ICraftingPatternProvider;
 import com.refinedmods.refinedstorage.api.util.IComparer;
 import com.refinedmods.refinedstorage.apiimpl.API;
 import com.refinedmods.refinedstorage.item.PatternItem;
@@ -35,7 +36,7 @@ public class IngredientTracker {
     public void addAvailableStack(ItemStack stack, @Nullable IGridStack gridStack) {
         int available = stack.getCount();
         if (doTransfer) {
-            if (stack.getItem() instanceof PatternItem) {
+            if (stack.getItem() instanceof ICraftingPatternProvider) {
                 ICraftingPattern pattern = PatternItem.fromCache(Minecraft.getInstance().world, stack);
                 if (pattern.isValid()) {
                     for (ItemStack outputStack : pattern.getOutputs()) {

--- a/src/main/java/com/refinedmods/refinedstorage/integration/jei/IngredientTracker.java
+++ b/src/main/java/com/refinedmods/refinedstorage/integration/jei/IngredientTracker.java
@@ -2,6 +2,7 @@ package com.refinedmods.refinedstorage.integration.jei;
 
 import com.refinedmods.refinedstorage.api.util.IComparer;
 import com.refinedmods.refinedstorage.apiimpl.API;
+import com.refinedmods.refinedstorage.item.PatternItem;
 import com.refinedmods.refinedstorage.screen.grid.stack.IGridStack;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.gui.ingredient.IGuiIngredient;
@@ -29,7 +30,12 @@ public class IngredientTracker {
 
     public void addAvailableStack(ItemStack stack, @Nullable IGridStack gridStack) {
         int available = stack.getCount();
-        storedItems.merge(stack.getItem().getRegistryName(), available, Integer::sum);
+        if (stack.getItem() instanceof PatternItem) {
+            ItemStack outputStack = PatternItem.getOutputSlot(stack, 0);
+            storedItems.merge(outputStack.getItem().getRegistryName(), available, Integer::sum);
+        } else {
+            storedItems.merge(stack.getItem().getRegistryName(), available, Integer::sum);
+        }
 
         for (Ingredient ingredient : ingredients) {
             if (available == 0) {

--- a/src/main/java/com/refinedmods/refinedstorage/integration/jei/IngredientTracker.java
+++ b/src/main/java/com/refinedmods/refinedstorage/integration/jei/IngredientTracker.java
@@ -1,5 +1,6 @@
 package com.refinedmods.refinedstorage.integration.jei;
 
+import com.refinedmods.refinedstorage.api.autocrafting.ICraftingPattern;
 import com.refinedmods.refinedstorage.api.util.IComparer;
 import com.refinedmods.refinedstorage.apiimpl.API;
 import com.refinedmods.refinedstorage.item.PatternItem;
@@ -8,7 +9,6 @@ import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.gui.ingredient.IGuiIngredient;
 import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 
 import javax.annotation.Nullable;
@@ -36,10 +36,13 @@ public class IngredientTracker {
         int available = stack.getCount();
         if (doTransfer) {
             if (stack.getItem() instanceof PatternItem) {
-                NonNullList<ItemStack> outputStacks = PatternItem.fromCache(Minecraft.getInstance().world, stack).getOutputs();
-                for (ItemStack outputStack : outputStacks) {
-                    storedItems.merge(outputStack.getItem().getRegistryName(), outputStack.getCount(), Integer::sum);
+                ICraftingPattern pattern = PatternItem.fromCache(Minecraft.getInstance().world, stack);
+                if (pattern.isValid()) {
+                    for (ItemStack outputStack : pattern.getOutputs()) {
+                        storedItems.merge(outputStack.getItem().getRegistryName(), outputStack.getCount(), Integer::sum);
+                    }
                 }
+
             } else {
                 storedItems.merge(stack.getItem().getRegistryName(), available, Integer::sum);
             }


### PR DESCRIPTION
When transfering items via JEI it will look up the most common item in the system and use that one instead of randomly picking. 
Implements #2921