### PR TITLE
Remove calculation threads causing concurrency issues

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/grid/handler/FluidGridHandler.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/grid/handler/FluidGridHandler.java
@@ -99,40 +99,36 @@ public class FluidGridHandler implements IFluidGridHandler {
         FluidStack stack = network.getFluidStorageCache().getCraftablesList().get(id);
 
         if (stack != null) {
-            Thread calculationThread = new Thread(() -> {
-                ICalculationResult result = network.getCraftingManager().create(stack, quantity);
-                if (result == null) {
-                    return;
-                }
+            ICalculationResult result = network.getCraftingManager().create(stack, quantity);
+            if (result == null) {
+                return;
+            }
 
-                if (!result.isOk() && result.getType() != CalculationResultType.MISSING) {
-                    RS.NETWORK_HANDLER.sendTo(
-                        player,
-                        new GridCraftingPreviewResponseMessage(
-                            Collections.singletonList(new ErrorCraftingPreviewElement(result.getType(), result.getRecursedPattern() == null ? ItemStack.EMPTY : result.getRecursedPattern().getStack())),
-                            id,
-                            quantity,
-                            true
-                        )
-                    );
-                } else if (result.isOk() && noPreview) {
-                    network.getCraftingManager().start(result.getTask());
+            if (!result.isOk() && result.getType() != CalculationResultType.MISSING) {
+                RS.NETWORK_HANDLER.sendTo(
+                    player,
+                    new GridCraftingPreviewResponseMessage(
+                        Collections.singletonList(new ErrorCraftingPreviewElement(result.getType(), result.getRecursedPattern() == null ? ItemStack.EMPTY : result.getRecursedPattern().getStack())),
+                        id,
+                        quantity,
+                        true
+                    )
+                );
+            } else if (result.isOk() && noPreview) {
+                network.getCraftingManager().start(result.getTask());
 
-                    RS.NETWORK_HANDLER.sendTo(player, new GridCraftingStartResponseMessage());
-                } else {
-                    RS.NETWORK_HANDLER.sendTo(
-                        player,
-                        new GridCraftingPreviewResponseMessage(
-                            result.getPreviewElements(),
-                            id,
-                            quantity,
-                            true
-                        )
-                    );
-                }
-            }, "RS crafting preview calculation");
-
-            calculationThread.start();
+                RS.NETWORK_HANDLER.sendTo(player, new GridCraftingStartResponseMessage());
+            } else {
+                RS.NETWORK_HANDLER.sendTo(
+                    player,
+                    new GridCraftingPreviewResponseMessage(
+                        result.getPreviewElements(),
+                        id,
+                        quantity,
+                        true
+                    )
+                );
+            }
         }
     }
 

--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/grid/handler/ItemGridHandler.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/grid/handler/ItemGridHandler.java
@@ -190,37 +190,33 @@ public class ItemGridHandler implements IItemGridHandler {
         ItemStack stack = network.getItemStorageCache().getCraftablesList().get(id);
 
         if (stack != null) {
-            Thread calculationThread = new Thread(() -> {
-                ICalculationResult result = network.getCraftingManager().create(stack, quantity);
+            ICalculationResult result = network.getCraftingManager().create(stack, quantity);
 
-                if (!result.isOk() && result.getType() != CalculationResultType.MISSING) {
-                    RS.NETWORK_HANDLER.sendTo(
-                        player,
-                        new GridCraftingPreviewResponseMessage(
-                            Collections.singletonList(new ErrorCraftingPreviewElement(result.getType(), result.getRecursedPattern() == null ? ItemStack.EMPTY : result.getRecursedPattern().getStack())),
-                            id,
-                            quantity,
-                            false
-                        )
-                    );
-                } else if (result.isOk() && noPreview) {
-                    network.getCraftingManager().start(result.getTask());
+            if (!result.isOk() && result.getType() != CalculationResultType.MISSING) {
+                RS.NETWORK_HANDLER.sendTo(
+                    player,
+                    new GridCraftingPreviewResponseMessage(
+                        Collections.singletonList(new ErrorCraftingPreviewElement(result.getType(), result.getRecursedPattern() == null ? ItemStack.EMPTY : result.getRecursedPattern().getStack())),
+                        id,
+                        quantity,
+                        false
+                    )
+                );
+            } else if (result.isOk() && noPreview) {
+                network.getCraftingManager().start(result.getTask());
 
-                    RS.NETWORK_HANDLER.sendTo(player, new GridCraftingStartResponseMessage());
-                } else {
-                    RS.NETWORK_HANDLER.sendTo(
-                        player,
-                        new GridCraftingPreviewResponseMessage(
-                            result.getPreviewElements(),
-                            id,
-                            quantity,
-                            false
-                        )
-                    );
-                }
-            }, "RS crafting preview calculation");
-
-            calculationThread.start();
+                RS.NETWORK_HANDLER.sendTo(player, new GridCraftingStartResponseMessage());
+            } else {
+                RS.NETWORK_HANDLER.sendTo(
+                    player,
+                    new GridCraftingPreviewResponseMessage(
+                        result.getPreviewElements(),
+                        id,
+                        quantity,
+                        false
+                    )
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #2995

This thread was first added 4 years ago for item crafting preview and then blindly copied (I assume) for unfinished fluid crafting preview.

I don't know how the code structure was back then, but now this method call is enqueued onto the main minecraft thread from the network thread and does not really block anything.
Given that the calculation is also called on the main thread when updating nodes and it's totally fine, I think it's ok to remove this thread which causes concurrency issues (at least #2995). Or this can also be changed to call that calculation at the end of the world tick near all the node processing.

There are no other threads across RS and no code is threadsafe, you need to at least add a bunch of synchronization to ItemStackList/FluidStackList so that calling their `copy` from another thread (like it happens now) is safe and does not cause CMEs if you want to keep the preview calculation threads as they are now.