### PR TITLE
Speed up pattern validation by using now-fixed cache

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/inventory/item/validator/PatternItemValidator.java
+++ b/src/main/java/com/refinedmods/refinedstorage/inventory/item/validator/PatternItemValidator.java
@@ -1,6 +1,8 @@
 package com.refinedmods.refinedstorage.inventory.item.validator;
 
+import com.refinedmods.refinedstorage.RSItems;
 import com.refinedmods.refinedstorage.api.autocrafting.ICraftingPatternProvider;
+import com.refinedmods.refinedstorage.item.PatternItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
@@ -15,6 +17,9 @@ public class PatternItemValidator implements Predicate<ItemStack> {
 
     @Override
     public boolean test(ItemStack stack) {
+        if (stack.getItem() == RSItems.PATTERN.get()) {
+            return PatternItem.fromCache(world, stack).isValid();
+        }
         return stack.getItem() instanceof ICraftingPatternProvider && ((ICraftingPatternProvider) stack.getItem()).create(world, stack, null).isValid();
     }
 }


### PR DESCRIPTION
I wanted to make this commit a part of #3010 but didn't make it in time :)

Speed things up for vanilla-RS patterns by using that cache, I've never ever seen any addon making their own patterns so this is pretty much universal at this point.

Creating ICrafterPattern instances is quite expensive in modpacks with bagilions of recipes so while this isn't really an issue for vanilla RS it helps a lot in those modpacks.