### PR TITLE
Implement ordered insertion

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/autocrafting/task/v6/IoUtil.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/autocrafting/task/v6/IoUtil.java
@@ -6,7 +6,6 @@ import com.refinedmods.refinedstorage.api.util.Action;
 import com.refinedmods.refinedstorage.api.util.IComparer;
 import com.refinedmods.refinedstorage.api.util.IStackList;
 import com.refinedmods.refinedstorage.api.util.StackListEntry;
-import com.refinedmods.refinedstorage.apiimpl.API;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
@@ -14,20 +13,21 @@ import java.util.ArrayList;
 import java.util.List;
 
 public final class IoUtil {
+
     private static final int DEFAULT_EXTRACT_FLAGS = IComparer.COMPARE_NBT;
 
     private IoUtil() {
     }
 
-    public static IStackList<ItemStack> extractFromInternalItemStorage(IStackList<ItemStack> list, IStorageDisk<ItemStack> storage, Action action) {
-        IStackList<ItemStack> extracted = API.instance().createItemStackList();
+    public static List<ItemStack> extractFromInternalItemStorage(List<ItemStack> stacks, IStorageDisk<ItemStack> storage, Action action) {
+        List<ItemStack> extracted = new ArrayList<>();
 
-        for (StackListEntry<ItemStack> entry : list.getStacks()) {
-            ItemStack result = storage.extract(entry.getStack(), entry.getStack().getCount(), DEFAULT_EXTRACT_FLAGS, action);
+        for (ItemStack stack : stacks) {
+            ItemStack result = storage.extract(stack, stack.getCount(), DEFAULT_EXTRACT_FLAGS, action);
 
-            if (result.isEmpty() || result.getCount() != entry.getStack().getCount()) {
+            if (result.isEmpty() || result.getCount() != stack.getCount()) {
                 if (action == Action.PERFORM) {
-                    throw new IllegalStateException("The internal crafting inventory reported that " + entry.getStack() + " was available but we got " + result);
+                    throw new IllegalStateException("The internal crafting inventory reported that " + stack + " was available but we got " + result);
                 }
 
                 return null;
@@ -39,15 +39,15 @@ public final class IoUtil {
         return extracted;
     }
 
-    public static IStackList<FluidStack> extractFromInternalFluidStorage(IStackList<FluidStack> list, IStorageDisk<FluidStack> storage, Action action) {
-        IStackList<FluidStack> extracted = API.instance().createFluidStackList();
+    public static List<FluidStack> extractFromInternalFluidStorage(List<FluidStack> stacks, IStorageDisk<FluidStack> storage, Action action) {
+        List<FluidStack> extracted = new ArrayList<>();
 
-        for (StackListEntry<FluidStack> entry : list.getStacks()) {
-            FluidStack result = storage.extract(entry.getStack(), entry.getStack().getAmount(), DEFAULT_EXTRACT_FLAGS, action);
+        for (FluidStack stack : stacks) {
+            FluidStack result = storage.extract(stack, stack.getAmount(), DEFAULT_EXTRACT_FLAGS, action);
 
-            if (result.isEmpty() || result.getAmount() != entry.getStack().getAmount()) {
+            if (result.isEmpty() || result.getAmount() != stack.getAmount()) {
                 if (action == Action.PERFORM) {
-                    throw new IllegalStateException("The internal crafting inventory reported that " + entry.getStack() + " was available but we got " + result);
+                    throw new IllegalStateException("The internal crafting inventory reported that " + stack + " was available but we got " + result);
                 }
 
                 return null;

--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/autocrafting/task/v6/node/NodeRequirements.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/autocrafting/task/v6/node/NodeRequirements.java
@@ -11,12 +11,10 @@ import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.items.ItemHandlerHelper;
 
 import javax.annotation.Nullable;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class NodeRequirements {
     private static final String NBT_ITEMS_TO_USE = "ItemsToUse";
@@ -32,9 +30,9 @@ public class NodeRequirements {
     private final Map<Integer, Integer> fluidsNeededPerCraft = new LinkedHashMap<>();
 
     @Nullable
-    private IStackList<ItemStack> cachedSimulatedItemRequirementSet = null;
+    private List<ItemStack> cachedSimulatedItemRequirementSet = null;
     @Nullable
-    private IStackList<FluidStack> cachedSimulatedFluidRequirementSet = null;
+    private List<FluidStack> cachedSimulatedFluidRequirementSet = null;
 
     public void addItemRequirement(int ingredientNumber, ItemStack stack, int size, int perCraft) {
         if (!itemsNeededPerCraft.containsKey(ingredientNumber)) {
@@ -56,13 +54,13 @@ public class NodeRequirements {
         cachedSimulatedFluidRequirementSet = null;
     }
 
-    public IStackList<ItemStack> getSingleItemRequirementSet(boolean simulate) {
-        IStackList<ItemStack> cached = cachedSimulatedItemRequirementSet;
+    public List<ItemStack> getSingleItemRequirementSet(boolean simulate) {
+        List<ItemStack> cached = cachedSimulatedItemRequirementSet;
         if (simulate && cached != null) {
             return cached;
         }
 
-        IStackList<ItemStack> toReturn = API.instance().createItemStackList();
+        List<ItemStack> toReturn = new ArrayList<>();
 
         for (int i = 0; i < itemRequirements.size(); i++) {
             int needed = itemsNeededPerCraft.get(i);
@@ -78,7 +76,7 @@ public class NodeRequirements {
                             itemRequirements.get(i).remove(toUse, needed);
                         }
 
-                        toReturn.add(toUse, needed);
+                        toReturn.add(ItemHandlerHelper.copyStackWithSize(toUse, needed));
 
                         needed = 0;
                     } else {
@@ -101,13 +99,13 @@ public class NodeRequirements {
         return toReturn;
     }
 
-    public IStackList<FluidStack> getSingleFluidRequirementSet(boolean simulate) {
-        IStackList<FluidStack> cached = cachedSimulatedFluidRequirementSet;
+    public List<FluidStack> getSingleFluidRequirementSet(boolean simulate) {
+        List<FluidStack> cached = cachedSimulatedFluidRequirementSet;
         if (simulate && cached != null) {
             return cached;
         }
 
-        IStackList<FluidStack> toReturn = API.instance().createFluidStackList();
+        List<FluidStack> toReturn = new ArrayList<>();
 
         for (int i = 0; i < fluidRequirements.size(); i++) {
             int needed = fluidsNeededPerCraft.get(i);
@@ -123,7 +121,9 @@ public class NodeRequirements {
                             fluidRequirements.get(i).remove(toUse, needed);
                         }
 
-                        toReturn.add(toUse, needed);
+                        FluidStack newStack = toUse.copy();
+                        newStack.setAmount(needed);
+                        toReturn.add(newStack);
 
                         needed = 0;
                     } else {

--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/util/FluidStackList.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/util/FluidStackList.java
@@ -19,6 +19,15 @@ public class FluidStackList implements IStackList<FluidStack> {
     private final ArrayListMultimap<Fluid, StackListEntry<FluidStack>> stacks = ArrayListMultimap.create();
     private final Map<UUID, FluidStack> index = new HashMap<>();
 
+    public FluidStackList() {
+    }
+
+    public FluidStackList(Iterable<FluidStack> stacks) {
+        for (FluidStack stack : stacks) {
+            add(stack);
+        }
+    }
+
     @Override
     public StackListResult<FluidStack> add(@Nonnull FluidStack stack, int size) {
         if (stack.isEmpty() || size <= 0) {

--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/util/ItemStackList.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/util/ItemStackList.java
@@ -20,6 +20,15 @@ public class ItemStackList implements IStackList<ItemStack> {
     private final ArrayListMultimap<Item, StackListEntry<ItemStack>> stacks = ArrayListMultimap.create();
     private final Map<UUID, ItemStack> index = new HashMap<>();
 
+    public ItemStackList() {
+    }
+
+    public ItemStackList(Iterable<ItemStack> stacks) {
+        for (ItemStack stack : stacks) {
+            add(stack);
+        }
+    }
+
     @Override
     public StackListResult<ItemStack> add(@Nonnull ItemStack stack, int size) {
         if (stack.isEmpty() || size <= 0) {


### PR DESCRIPTION
This is the simplest and unlikely to be broken in any way implementation of #1937

Basically, I just changed `IoUtil.insertIntoInventory` from accepting unordered `Collection` to a `List`, and then went on from that.

This collection is obtained exclusively through ItemStackList.getStacks(), which is explicitly unordered as it merges stacks, makes sense.

So then I refactored a couple of methods that are used only in autocrafting to use lists of stacks instead of `ItemStackList`s, it was smooth as hell, and everything worked first try.

This means that those stacks are _not_ merged in a couple of cases, but I think that's actually desired, I can imagine a usecase for when the processing pattern can insert items in order, like A -> B -> C, and then A again into some specific machines.

I did some testing with ATM6, everything seems to just work.

resolves #1937