### PR TITLE
Reuse ItemExternalStorageCache to avoid excessive calls to getStackInSlot

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/FluidExternalStorage.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/FluidExternalStorage.java
@@ -117,19 +117,7 @@ public class FluidExternalStorage implements IExternalStorage<FluidStack> {
 
     @Override
     public int getStored() {
-        IFluidHandler fluidHandler = handlerSupplier.get();
-
-        if (fluidHandler != null) {
-            int stored = 0;
-
-            for (int i = 0; i < fluidHandler.getTanks(); ++i) {
-                stored += fluidHandler.getFluidInTank(i).getAmount();
-            }
-
-            return stored;
-        }
-
-        return 0;
+        return cache.getStored();
     }
 
     @Override

--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/FluidExternalStorageCache.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/FluidExternalStorageCache.java
@@ -12,24 +12,36 @@ import java.util.List;
 
 public class FluidExternalStorageCache {
     private List<FluidStack> cache;
+    private int stored = 0;
+
+    public int getStored() {
+        return stored;
+    }
 
     public void update(INetwork network, @Nullable IFluidHandler handler) {
         if (handler == null) {
+            stored = 0;
             return;
         }
 
         if (cache == null) {
             cache = new ArrayList<>();
 
+            int stored = 0;
             for (int i = 0; i < handler.getTanks(); ++i) {
-                cache.add(handler.getFluidInTank(i).copy());
+                FluidStack stack = handler.getFluidInTank(i).copy();
+                cache.add(stack);
+                stored += stack.getAmount();
             }
+            this.stored = stored;
 
             return;
         }
 
+        int stored = 0;
         for (int i = 0; i < handler.getTanks(); ++i) {
             FluidStack actual = handler.getFluidInTank(i);
+            stored += actual.getAmount();
 
             if (i >= cache.size()) { // ENLARGED
                 if (!actual.isEmpty()) {
@@ -70,6 +82,7 @@ public class FluidExternalStorageCache {
                 cached.setAmount(actual.getAmount());
             }
         }
+        this.stored = stored;
 
         if (cache.size() > handler.getTanks()) { // SHRUNK
             for (int i = cache.size() - 1; i >= handler.getTanks(); --i) { // Reverse order for the remove call.

--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/ItemExternalStorage.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/ItemExternalStorage.java
@@ -137,19 +137,7 @@ public class ItemExternalStorage implements IExternalStorage<ItemStack> {
 
     @Override
     public int getStored() {
-        IItemHandler handler = handlerSupplier.get();
-
-        if (handler == null) {
-            return 0;
-        }
-
-        int size = 0;
-
-        for (int i = 0; i < handler.getSlots(); ++i) {
-            size += handler.getStackInSlot(i).getCount();
-        }
-
-        return size;
+        return cache.getStored();
     }
 
     @Override

--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/ItemExternalStorageCache.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/ItemExternalStorageCache.java
@@ -11,24 +11,36 @@ import java.util.List;
 
 public class ItemExternalStorageCache {
     private List<ItemStack> cache;
+    private int stored = 0;
+
+    public int getStored() {
+        return stored;
+    }
 
     public void update(INetwork network, @Nullable IItemHandler handler) {
         if (handler == null) {
+            stored = 0;
             return;
         }
 
         if (cache == null) {
             cache = new ArrayList<>();
 
+            int stored = 0;
             for (int i = 0; i < handler.getSlots(); ++i) {
-                cache.add(handler.getStackInSlot(i).copy());
+                ItemStack stack = handler.getStackInSlot(i).copy();
+                cache.add(stack);
+                stored += stack.getCount();
             }
+            this.stored = stored;
 
             return;
         }
 
+        int stored = 0;
         for (int i = 0; i < handler.getSlots(); ++i) {
             ItemStack actual = handler.getStackInSlot(i);
+            stored += actual.getCount();
 
             if (i >= cache.size()) { // ENLARGED
                 if (!actual.isEmpty()) {
@@ -69,6 +81,7 @@ public class ItemExternalStorageCache {
                 }
             }
         }
+        this.stored = stored;
 
         if (cache.size() > handler.getSlots()) { // SHRUNK
             for (int i = cache.size() - 1; i >= handler.getSlots(); --i) { // Reverse order for the remove call.


### PR DESCRIPTION
`getStored` is called a lot of times in certain scenarios (e.g. #2996) and it calls `getStackInSlot` a lot, implementors of which can do whatever they want - e.g. copy ItemStacks on each call or do other unoptimized things, like StorageDrawers do.

This simple patch avoids that by caching the stored amount as part of existing caching algorithm in `ItemExternalStorageCache`, very simple, avoids calling getStackInSlot a ton of times per tick.

Should noticeably (75% of that spark report) help with performance for #2996, although I don't think it is the root cause so idk if it closes it.