### PR TITLE
 Fix override of Pattern color even when not in player inventory

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/render/model/PatternBakedModel.java
+++ b/src/main/java/com/refinedmods/refinedstorage/render/model/PatternBakedModel.java
@@ -11,6 +11,7 @@ import net.minecraft.client.renderer.model.ItemOverride;
 import net.minecraft.client.renderer.model.ItemOverrideList;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.ItemStack;
 
 import javax.annotation.Nullable;
@@ -47,10 +48,13 @@ public class PatternBakedModel extends DelegateBakedModel {
     }
 
     public static boolean canDisplayOutput(ItemStack patternStack, ICraftingPattern pattern) {
-        if (pattern.isValid() && pattern.getOutputs().size() == 1) {
-            for (ICraftingPatternRenderHandler renderHandler : API.instance().getPatternRenderHandlers()) {
-                if (renderHandler.canRenderOutput(patternStack)) {
-                    return true;
+        if (pattern.isValid() && pattern.getOutputs().size() == 1 && Minecraft.getInstance().player != null) {
+            PlayerInventory inventory = Minecraft.getInstance().player.inventory;
+            if (inventory.mainInventory.contains(patternStack) || inventory.offHandInventory.contains(patternStack) || inventory.armorInventory.contains(patternStack)) {
+                for (ICraftingPatternRenderHandler renderHandler : API.instance().getPatternRenderHandlers()) {
+                    if (renderHandler.canRenderOutput(patternStack)) {
+                        return true;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fix #2980
This is the issue where RS Patterns with an overridden color (example: leaves) change their color (but not their model) in item frames, JEI favorites, an RS Grid, when dropped, and everywhere else that isn't the current players inventory.
​

The issue occurs because ``PatternItemColor.getColor(stack, tintIndex)`` only checks ``PatternBakedModel.canDisplayOutput(stack, pattern)``:
https://github.com/refinedmods/refinedstorage/blob/d98872c3101c8b2c2d2af21541771fe24ce7d0e7/src/main/java/com/refinedmods/refinedstorage/render/color/PatternItemColor.java#L15

The override for the actual model in ``PatternBakedModel`` -> ``getOverrideModel(model, stack, world, entity)`` first checks if the entity isn't null:
https://github.com/refinedmods/refinedstorage/blob/d98872c3101c8b2c2d2af21541771fe24ce7d0e7/src/main/java/com/refinedmods/refinedstorage/render/model/PatternBakedModel.java#L29-L32
​

To fix this and prevent further "edge-cases", a check is added in``PatternBakedModel.canDisplayOutput(stack, pattern)`` to see if the exact ItemStack (for the color override) is even in the players inventory.
(Note: ``Minecraft.getInstance().player.inventory.hasItemStack(stack)`` could not be used, as that just checks if the Item is present in the inventory at all (not the specific ItemStack))

(Tested in Singleplayer and Multiplayer)
​

Additional notes about the code:
- I'm not sure if the ``Minecraft.getInstance().player != null`` check is needed but it also doesn't hurt I guess.
- I would have liked to just check ``Minecraft.getInstance().player.inventory.allInventories`` (a combined list of all three inventory lists) but it's private.
- I also included ``armorInventory`` because this is also part of the players inventory and technically (either by bug or cheating), a pattern could be put there producing the same bug again.

If there's anything that could or should be done differently, please let me know and I'll update the PR.
(Maintainer edits are also allowed of course)