### PR TITLE
Fix override of Pattern color

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/setup/ClientSetup.java
+++ b/src/main/java/com/refinedmods/refinedstorage/setup/ClientSetup.java
@@ -144,7 +144,7 @@ public class ClientSetup {
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onModelRegistry);
         MinecraftForge.EVENT_BUS.addListener(this::addReloadListener);
 
-        API.instance().addPatternRenderHandler(pattern -> Screen.hasShiftDown());
+        API.instance().addPatternRenderHandler(pattern -> Screen.hasShiftDown() && Minecraft.getInstance().player.openContainer.getInventory().contains(pattern));
 
         API.instance().addPatternRenderHandler(pattern -> {
             Container container = Minecraft.getInstance().player.openContainer;


### PR DESCRIPTION
Fix #2980
This is the issue where RS Patterns with an overridden color (example: leaves) change their color (but not their model) in item frames, JEI favorites, an RS Grid, when dropped, and everywhere else that isn't the current players inventory.

I previously attempted to fix this in #3060 (this PR uses "another (cleaner) approach" hence I didn't update the original PR).
This PR should keep current behavior that was broken by the other PR (shifting in a Pattern Grid did not show the output and more for a "programmed pattern", it also didn't show in chests and other container when shifting).
​

The issue occurs because ``PatternItemColor.getColor(stack, tintIndex)`` only checks ``PatternBakedModel.canDisplayOutput(stack, pattern)``:
https://github.com/refinedmods/refinedstorage/blob/d98872c3101c8b2c2d2af21541771fe24ce7d0e7/src/main/java/com/refinedmods/refinedstorage/render/color/PatternItemColor.java#L15

The override for the actual model in ``PatternBakedModel`` -> ``getOverrideModel(model, stack, world, entity)`` first checks if the entity isn't null:
https://github.com/refinedmods/refinedstorage/blob/d98872c3101c8b2c2d2af21541771fe24ce7d0e7/src/main/java/com/refinedmods/refinedstorage/render/model/PatternBakedModel.java#L29-L32
​

To fix this, the PatternRenderHandler, which checks if the shift key is down, is updated to also check if the ItemStack of the pattern is currently present in the inventory of the open container (``PlayerContainer`` returns a list of all ItemStacks in the player inventory when no UI is opened hence this doesn't need to explicitly check mainInventory/offHandInventory).
(Tested in Singleplayer and Multiplayer)
​

If there's anything that could or should be done differently, please let me know and I'll update the PR.
(Maintainer edits are also allowed of course)