### PR TITLE
Fix right-clicking NetworkItem in offhand locking wrong slot

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/item/NetworkItem.java
+++ b/src/main/java/com/refinedmods/refinedstorage/item/NetworkItem.java
@@ -38,7 +38,7 @@ public abstract class NetworkItem extends EnergyItem implements INetworkItemProv
         ItemStack stack = player.getHeldItem(hand);
 
         if (!world.isRemote) {
-            applyNetwork(world.getServer(), stack, n -> n.getNetworkItemManager().open(player, player.getHeldItem(hand), player.inventory.currentItem), err -> player.sendMessage(err, player.getUniqueID()));
+            applyNetwork(world.getServer(), stack, n -> n.getNetworkItemManager().open(player, stack, hand == Hand.OFF_HAND ? 40 : player.inventory.currentItem), err -> player.sendMessage(err, player.getUniqueID()));
         }
 
         return ActionResult.resultSuccess(stack);

--- a/src/main/java/com/refinedmods/refinedstorage/item/blockitem/PortableGridBlockItem.java
+++ b/src/main/java/com/refinedmods/refinedstorage/item/blockitem/PortableGridBlockItem.java
@@ -50,7 +50,7 @@ public class PortableGridBlockItem extends EnergyBlockItem {
         ItemStack stack = player.getHeldItem(hand);
 
         if (!world.isRemote) {
-            API.instance().getGridManager().openGrid(PortableGridGridFactory.ID, (ServerPlayerEntity) player, stack, player.inventory.currentItem);
+            API.instance().getGridManager().openGrid(PortableGridGridFactory.ID, (ServerPlayerEntity) player, stack, hand == Hand.OFF_HAND ? 40 : player.inventory.currentItem);
         }
 
         return ActionResult.resultSuccess(stack);


### PR DESCRIPTION
Fix #2997

This is fixed by checking if the right-clicking action on the NetworkItem/wireless grid was performed by the main- or offhand.
If it's performed by the offhand, slot 40 instead of the currently selected slot on the hotbar "gets locked".
(This slot isn't actually visible in the GUI opened. Passing down ``-1`` also works in my testing but since ``40`` is apparently the slot used for the offhand, I used that.)

``Minecraft.getInstance().player.inventory.getStackInSlot(40)`` returns the ItemStack in the offhand. It doesn't look like there's a constant/value for this in Minecraft classes.

(``-106`` is apparently the slot used when saving the offhand as NBT(?))

Note: I also replaced `` player.getHeldItem(hand)`` in the same line with ``stack`` (as the value was initialized directly above and is the same).