### PR TITLE
Jenkinsfile without the caching and publishing

### DIFF
--- a/Jenkinsfile_nocache_nopublish
+++ b/Jenkinsfile_nocache_nopublish
@@ -1,0 +1,17 @@
+node {
+  stage('Preparation') {
+    checkout scm
+  }
+  stage('Cleanup') {
+    sh "./gradlew clean"
+  }
+  stage('Test') {
+    sh "./gradlew test"
+  }
+  stage('Build') {
+    sh "./gradlew build"
+  }
+  stage('Archive artifacts') {
+    archiveArtifacts 'build/libs/*.jar'
+  }
+}


### PR DESCRIPTION
Hi,

I'd like to see this 'no cache, no publish' Jenkinsfile, because
- the Jenkins Job Cacher Plugin is extremely out of date and doesn't work properly with the 'recent' Controller Isolation (https://www.jenkins.io/doc/book/security/controller-isolation/#agent-controller-access-control) (you need to allow almost  full access to JENKINS_HOME globally. Additonally it performs so slowly, that it often is interrupted by jenkins, before it completes)
- Not everyone wants the output files published to the `/var/www/repo` folder. (Either because they don't want to open a Maven Repo at all or are using the Jenkins Maven repo plugin)
- this results in more predictable Pipeline execution on build-nodes
- your own build-server is out of storage-space

I'd also like this jenkinsfile to be added to the other branches (1.14, 1.15, ...), but can fully understand, if you consider those 'no longer supported'

Greetings
