### PR TITLE
Added caching to the CraftingManager

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/autocrafting/CraftingManager.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/autocrafting/CraftingManager.java
@@ -40,8 +40,8 @@ public class CraftingManager implements ICraftingManager {
     private final Map<ICraftingPattern, Set<ICraftingPatternContainer>> patternToContainer = new HashMap<>();
 
     private final List<ICraftingPattern> patterns = new ArrayList<>();
-    private final Map<CompoundNBT, ICraftingPattern> fluidPatternCache = new HashMap<>();
-    private final Map<CompoundNBT, ICraftingPattern> itemPatternCache = new HashMap<>();
+    private final Map<Integer, ICraftingPattern> fluidPatternCache = new HashMap<>();
+    private final Map<Integer, ICraftingPattern> itemPatternCache = new HashMap<>();
 
     private final Map<UUID, ICraftingTask> tasks = new LinkedHashMap<>();
     private final List<ICraftingTask> tasksToAdd = new ArrayList<>();
@@ -416,12 +416,12 @@ public class CraftingManager implements ICraftingManager {
     @Nullable
     @Override
     public ICraftingPattern getPattern(ItemStack pattern) {
-        return itemPatternCache.computeIfAbsent(pattern.getTag(), patternTag -> {
-            if (patternTag == null)
+        return itemPatternCache.computeIfAbsent(Objects.hash(pattern.getItem(), pattern.getTag()), patternKey -> {
+            if (patternKey == null)
                 return null;
             for (ICraftingPattern patternInList : patterns) {
                 for (ItemStack output : patternInList.getOutputs()) {
-                    if (patternTag.equals(output.getTag()))
+                    if (patternKey.equals(Objects.hash(output.getItem(), output.getTag())))
                         return patternInList;
                 }
             }
@@ -432,10 +432,11 @@ public class CraftingManager implements ICraftingManager {
     @Nullable
     @Override
     public ICraftingPattern getPattern(FluidStack pattern) {
-        return fluidPatternCache.computeIfAbsent(pattern.getTag(), patternTag -> {
+        return fluidPatternCache.computeIfAbsent(Objects.hash(pattern.getFluid(), pattern.getTag()), patternKey -> {
             for (ICraftingPattern patternInList : patterns) {
                 for (FluidStack output : patternInList.getFluidOutputs()) {
-                    if (patternTag.equals(output.getTag()))
+                    final Integer outputKey = Objects.hash(output.getFluid(), output.getTag());
+                    if (patternKey.equals(outputKey))
                         return patternInList;
                 }
             }


### PR DESCRIPTION
On a server with a lot of patterns we were seeing crashes like this:

```
java.lang.Error: ServerHangWatchdog detected that a single server tick took 72.90 seconds (should be max 0.05)
	at java.util.AbstractList$Itr.hasNext(AbstractList.java:351) ~[?:1.8.0_201] {}
	at com.refinedmods.refinedstorage.apiimpl.autocrafting.CraftingManager.getPattern(CraftingManager.java:416) ~[refinedstorage:1.9.15] {re:classloading}
	at com.refinedmods.refinedstorage.apiimpl.autocrafting.CraftingManager.create(CraftingManager.java:94) ~[refinedstorage:1.9.15] {re:classloading}
	at com.refinedmods.refinedstorage.apiimpl.autocrafting.CraftingManager.request(CraftingManager.java:256) ~[refinedstorage:1.9.15] {re:classloading}
	at com.refinedmods.refinedstorage.apiimpl.network.node.InterfaceNetworkNode.update(InterfaceNetworkNode.java:119) ~[refinedstorage:1.9.15] {re:classloading}
	at com.refinedmods.refinedstorage.apiimpl.network.NetworkListener.onWorldTick(NetworkListener.java:25) ~[refinedstorage:1.9.15] {re:classloading}
	at net.minecraftforge.eventbus.ASMEventHandler_620_NetworkListener_onWorldTick_WorldTickEvent.invoke(.dynamic) ~[?:?] {}
	at net.minecraftforge.eventbus.ASMEventHandler.invoke(ASMEventHandler.java:85) ~[eventbus-4.0.0.jar:?] {}
	at net.minecraftforge.eventbus.EventBus$$Lambda$2543/178210337.invoke(Unknown Source) ~[?:?] {}
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:302) ~[eventbus-4.0.0.jar:?] {}
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:283) ~[eventbus-4.0.0.jar:?] {}
	at net.minecraftforge.fml.hooks.BasicEventHooks.onPostWorldTick(BasicEventHooks.java:100) ~[forge:?] {re:classloading}
	at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:857) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:globaldataandresourcepacks.mixins.json:MinecraftServerMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:291) ~[?:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:787) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:globaldataandresourcepacks.mixins.json:MinecraftServerMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.server.MinecraftServer.func_240802_v_(MinecraftServer.java:642) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:globaldataandresourcepacks.mixins.json:MinecraftServerMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.server.MinecraftServer.func_240783_a_(MinecraftServer.java:232) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:globaldataandresourcepacks.mixins.json:MinecraftServerMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.server.MinecraftServer$$Lambda$14309/1505484318.run(Unknown Source) ~[?:?] {}
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_201] {}
```

where getPattern was taking a long time to go through them all, so have added caching which resolved the issue.