### PR TITLE
Fix shift crafting trusting storage cache too much

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Improved Performance for grid updates
 
+### Fixed
+
+- Fixed a dupe bug related to shift crafting
+
 ## [v1.10.2] - 2022-03-26
 
 ### Changed

--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/grid/CraftingGridBehavior.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/network/grid/CraftingGridBehavior.java
@@ -13,7 +13,6 @@ import com.refinedmods.refinedstorage.apiimpl.network.node.GridNetworkNode;
 import com.refinedmods.refinedstorage.item.PatternItem;
 import net.minecraft.core.NonNullList;
 import net.minecraft.world.Containers;
-import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.item.Item;
@@ -106,7 +105,7 @@ public class CraftingGridBehavior implements ICraftingGridBehavior {
             recipe.put(i, stack);
         }
 
-        int maxCrafted = getToCraftAmount(crafted, player.getInventory());
+        int maxCrafted = crafted.getMaxStackSize();
 
         int amountCrafted = 0;
         boolean useNetwork = network != null && grid.isGridActive();
@@ -232,16 +231,6 @@ public class CraftingGridBehavior implements ICraftingGridBehavior {
         });
 
         return amountCrafted - failed;
-    }
-
-    private int getToCraftAmount(ItemStack crafted, Inventory inventory) {
-        for (ItemStack stack : inventory.items) {
-            if (API.instance().getComparer().isEqual(stack, crafted, IComparer.COMPARE_NBT) && stack.getCount() < stack.getMaxStackSize()) {
-                return stack.getMaxStackSize() - stack.getCount();
-            }
-        }
-
-        return crafted.getMaxStackSize();
     }
 
     private void filterDuplicateStacks(INetwork network, CraftingContainer matrix, IStackList<ItemStack> availableItems) {

--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/ItemExternalStorage.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/ItemExternalStorage.java
@@ -113,8 +113,7 @@ public class ItemExternalStorage implements IExternalStorage<ItemStack> {
         for (int i = 0; i < handler.getSlots(); ++i) {
             ItemStack slot = handler.getStackInSlot(i);
 
-            //Default extract from Forge only allows extracting a maximum of 64 items at a time
-            while (!slot.isEmpty() && remaining > 0 && API.instance().getComparer().isEqual(slot, stack, flags)) {
+            if (!slot.isEmpty() && API.instance().getComparer().isEqual(slot, stack, flags)) {
                 ItemStack got = handler.extractItem(i, remaining, action == Action.SIMULATE);
 
                 if (!got.isEmpty()) {
@@ -125,13 +124,11 @@ public class ItemExternalStorage implements IExternalStorage<ItemStack> {
                     }
 
                     remaining -= got.getCount();
-                } else {
-                    break;
-                }
-            }
 
-            if (remaining == 0) {
-                break;
+                    if (remaining == 0) {
+                        break;
+                    }
+                }
             }
         }
 

--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/ItemExternalStorage.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/ItemExternalStorage.java
@@ -113,7 +113,8 @@ public class ItemExternalStorage implements IExternalStorage<ItemStack> {
         for (int i = 0; i < handler.getSlots(); ++i) {
             ItemStack slot = handler.getStackInSlot(i);
 
-            if (!slot.isEmpty() && API.instance().getComparer().isEqual(slot, stack, flags)) {
+            //Default extract from Forge only allows extracting a maximum of 64 items at a time
+            while (!slot.isEmpty() && remaining > 0 && API.instance().getComparer().isEqual(slot, stack, flags)) {
                 ItemStack got = handler.extractItem(i, remaining, action == Action.SIMULATE);
 
                 if (!got.isEmpty()) {
@@ -124,11 +125,13 @@ public class ItemExternalStorage implements IExternalStorage<ItemStack> {
                     }
 
                     remaining -= got.getCount();
-
-                    if (remaining == 0) {
-                        break;
-                    }
+                } else {
+                    break;
                 }
+            }
+
+            if (remaining == 0) {
+                break;
             }
         }
 


### PR DESCRIPTION
Fixes #3242. A fairly simple to use dupe bug. So it might be a good idea to backport this one.

This contains a slight behavior change for autocrafting. Extraction from inventories that use the default forge implementation, will now be much faster since the extraction will happen in the first tick. Shouldn't make much of a difference, though. 

Poll results: https://docs.google.com/forms/d/1K8F7qAZwh8Vo4lkunuORUVBOffI7bBKJhM596jVokXs/viewanalytics

The results of the poll confirm we are doing everything right. Although, we could consider changing this to produce 5 instead of 64. 
![image](https://user-images.githubusercontent.com/4283717/164996664-80bda759-43a1-432a-85e6-9da7efae6789.png)
