### PR TITLE
Fixes potential Pattern crash when loading Minecraft for 1.16.5

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/item/PatternItem.java
+++ b/src/main/java/com/refinedmods/refinedstorage/item/PatternItem.java
@@ -73,7 +73,7 @@ public class PatternItem extends Item implements ICraftingPatternProvider {
     public void addInformation(ItemStack stack, @Nullable World world, List<ITextComponent> tooltip, ITooltipFlag flag) {
         super.addInformation(stack, world, tooltip, flag);
 
-        if (!stack.hasTag()) {
+        if (!stack.hasTag() || world == null) {
             return;
         }
 

--- a/src/main/java/com/refinedmods/refinedstorage/render/tesr/PatternItemStackTileRenderer.java
+++ b/src/main/java/com/refinedmods/refinedstorage/render/tesr/PatternItemStackTileRenderer.java
@@ -3,6 +3,7 @@ package com.refinedmods.refinedstorage.render.tesr;
 import com.mojang.blaze3d.matrix.MatrixStack;
 import com.refinedmods.refinedstorage.api.autocrafting.ICraftingPattern;
 import com.refinedmods.refinedstorage.item.PatternItem;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.IRenderTypeBuffer;
 import net.minecraft.client.renderer.model.ItemCameraTransforms;
 import net.minecraft.client.renderer.tileentity.ItemStackTileEntityRenderer;
@@ -11,7 +12,7 @@ import net.minecraft.item.ItemStack;
 public class PatternItemStackTileRenderer extends ItemStackTileEntityRenderer {
     @Override
     public void func_239207_a_(ItemStack stack, ItemCameraTransforms.TransformType transformType, MatrixStack matrixStack, IRenderTypeBuffer renderTypeBuffer, int combinedLight, int combinedOverlay) {
-        ICraftingPattern pattern = PatternItem.fromCache(null, stack);
+        ICraftingPattern pattern = PatternItem.fromCache(Minecraft.getInstance().world, stack);
 
         ItemStack outputStack = pattern.getOutputs().get(0);
 


### PR DESCRIPTION
This addresses issue #3129 for 1.16.5
Hoping this can be merged in and released, had to do it myself and build the JAR for my friends who wanted to use Electrodynamics and Refined Storage together as this conflict caused the crash mentioned in issue #3129