### PR TITLE
LootItemFunctionType now use DeferredRegister

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,7 @@ processResources {
 }
 
 dependencies {
-    minecraft 'net.minecraftforge:forge:1.18.2-40.0.32'
+    minecraft 'net.minecraftforge:forge:1.18.2-40.1.48'
 
     compileOnly fg.deobf("mezz.jei:jei-1.18.2:9.5.4.171:api")
     runtimeOnly fg.deobf("mezz.jei:jei-1.18.2:9.5.4.171")
@@ -122,7 +122,7 @@ jar {
                 "Specification-Vendor"    : "refinedmods",
                 "Specification-Version"   : "1",
                 "Implementation-Title"    : project.name,
-                "Implementation-Version"  : "${version}",
+                "Implementation-Version"  : project.jar.archiveVersion,
                 "Implementation-Vendor"   : "refinedmods",
                 "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
         ])

--- a/src/main/java/com/refinedmods/refinedstorage/RS.java
+++ b/src/main/java/com/refinedmods/refinedstorage/RS.java
@@ -48,6 +48,7 @@ public final class RS {
 
         RSBlocks.register();
         RSItems.register();
+        RSLootFunctions.register();
 
         FMLJavaModLoadingContext.get().getModEventBus().addListener(CommonSetup::onCommonSetup);
         FMLJavaModLoadingContext.get().getModEventBus().addGenericListener(BlockEntityType.class, CommonSetup::onRegisterBlockEntities);

--- a/src/main/java/com/refinedmods/refinedstorage/RSLootFunctions.java
+++ b/src/main/java/com/refinedmods/refinedstorage/RSLootFunctions.java
@@ -5,38 +5,30 @@ import com.refinedmods.refinedstorage.loottable.CrafterLootFunction;
 import com.refinedmods.refinedstorage.loottable.PortableGridBlockLootFunction;
 import com.refinedmods.refinedstorage.loottable.StorageBlockLootFunction;
 import net.minecraft.core.Registry;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.storage.loot.functions.LootItemFunctionType;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.RegistryObject;
 
 public final class RSLootFunctions {
-    private static LootItemFunctionType storageBlock;
-    private static LootItemFunctionType portableGrid;
-    private static LootItemFunctionType crafter;
-    private static LootItemFunctionType controller;
+    public static final RegistryObject<LootItemFunctionType> STORAGE_BLOCK;
+    public static final RegistryObject<LootItemFunctionType> PORTABLE_GRID;
+    public static final RegistryObject<LootItemFunctionType> CRAFTER;
+    public static final RegistryObject<LootItemFunctionType> CONTROLLER;
+
+    private static final DeferredRegister<LootItemFunctionType> LOOT_ITEM_FUNCTIONS = DeferredRegister.create(Registry.LOOT_FUNCTION_REGISTRY, RS.ID);
+
+    static {
+        STORAGE_BLOCK = LOOT_ITEM_FUNCTIONS.register("storage_block", () -> new LootItemFunctionType(new StorageBlockLootFunction.Serializer()));
+        PORTABLE_GRID = LOOT_ITEM_FUNCTIONS.register("portable_grid", () -> new LootItemFunctionType(new PortableGridBlockLootFunction.Serializer()));
+        CRAFTER = LOOT_ITEM_FUNCTIONS.register("crafter", () -> new LootItemFunctionType(new CrafterLootFunction.Serializer()));
+        CONTROLLER = LOOT_ITEM_FUNCTIONS.register("controller", () -> new LootItemFunctionType(new ControllerLootFunction.Serializer()));
+    }
 
     private RSLootFunctions() {
     }
 
     public static void register() {
-        storageBlock = Registry.register(Registry.LOOT_FUNCTION_TYPE, new ResourceLocation(RS.ID, "storage_block"), new LootItemFunctionType(new StorageBlockLootFunction.Serializer()));
-        portableGrid = Registry.register(Registry.LOOT_FUNCTION_TYPE, new ResourceLocation(RS.ID, "portable_grid"), new LootItemFunctionType(new PortableGridBlockLootFunction.Serializer()));
-        crafter = Registry.register(Registry.LOOT_FUNCTION_TYPE, new ResourceLocation(RS.ID, "crafter"), new LootItemFunctionType(new CrafterLootFunction.Serializer()));
-        controller = Registry.register(Registry.LOOT_FUNCTION_TYPE, new ResourceLocation(RS.ID, "controller"), new LootItemFunctionType(new ControllerLootFunction.Serializer()));
-    }
-
-    public static LootItemFunctionType getStorageBlock() {
-        return storageBlock;
-    }
-
-    public static LootItemFunctionType getPortableGrid() {
-        return portableGrid;
-    }
-
-    public static LootItemFunctionType getCrafter() {
-        return crafter;
-    }
-
-    public static LootItemFunctionType getController() {
-        return controller;
+        LOOT_ITEM_FUNCTIONS.register(FMLJavaModLoadingContext.get().getModEventBus());
     }
 }

--- a/src/main/java/com/refinedmods/refinedstorage/loottable/ControllerLootFunction.java
+++ b/src/main/java/com/refinedmods/refinedstorage/loottable/ControllerLootFunction.java
@@ -38,7 +38,7 @@ public class ControllerLootFunction extends LootItemConditionalFunction {
 
     @Override
     public LootItemFunctionType getType() {
-        return RSLootFunctions.getController();
+        return RSLootFunctions.CONTROLLER.get();
     }
 
     public static class Serializer extends LootItemConditionalFunction.Serializer<ControllerLootFunction> {

--- a/src/main/java/com/refinedmods/refinedstorage/loottable/CrafterLootFunction.java
+++ b/src/main/java/com/refinedmods/refinedstorage/loottable/CrafterLootFunction.java
@@ -40,7 +40,7 @@ public class CrafterLootFunction extends LootItemConditionalFunction {
 
     @Override
     public LootItemFunctionType getType() {
-        return RSLootFunctions.getCrafter();
+        return RSLootFunctions.CRAFTER.get();
     }
 
     public static class Serializer extends LootItemConditionalFunction.Serializer<CrafterLootFunction> {

--- a/src/main/java/com/refinedmods/refinedstorage/loottable/PortableGridBlockLootFunction.java
+++ b/src/main/java/com/refinedmods/refinedstorage/loottable/PortableGridBlockLootFunction.java
@@ -30,7 +30,7 @@ public class PortableGridBlockLootFunction extends LootItemConditionalFunction {
 
     @Override
     public LootItemFunctionType getType() {
-        return RSLootFunctions.getPortableGrid();
+        return RSLootFunctions.PORTABLE_GRID.get();
     }
 
     public static class Serializer extends LootItemConditionalFunction.Serializer<PortableGridBlockLootFunction> {

--- a/src/main/java/com/refinedmods/refinedstorage/loottable/StorageBlockLootFunction.java
+++ b/src/main/java/com/refinedmods/refinedstorage/loottable/StorageBlockLootFunction.java
@@ -51,7 +51,7 @@ public class StorageBlockLootFunction extends LootItemConditionalFunction {
 
     @Override
     public LootItemFunctionType getType() {
-        return RSLootFunctions.getStorageBlock();
+        return RSLootFunctions.STORAGE_BLOCK.get();
     }
 
     public static class Serializer extends LootItemConditionalFunction.Serializer<StorageBlockLootFunction> {

--- a/src/main/java/com/refinedmods/refinedstorage/setup/CommonSetup.java
+++ b/src/main/java/com/refinedmods/refinedstorage/setup/CommonSetup.java
@@ -159,9 +159,6 @@ public final class CommonSetup {
 
     @SubscribeEvent
     public static void onRegisterBlockEntities(RegistryEvent.Register<BlockEntityType<?>> e) {
-        // Register here, there seems to be no specific register event for loot function types.
-        RSLootFunctions.register();
-
         e.getRegistry().register(registerSynchronizationParameters(BlockEntityType.Builder.of((pos, state) -> new ControllerBlockEntity(NetworkType.NORMAL, pos, state), RSBlocks.CONTROLLER.getBlocks()).build(null).setRegistryName(RS.ID, "controller")));
         e.getRegistry().register(registerSynchronizationParameters(BlockEntityType.Builder.of((pos, state) -> new ControllerBlockEntity(NetworkType.CREATIVE, pos, state), RSBlocks.CREATIVE_CONTROLLER.getBlocks()).build(null).setRegistryName(RS.ID, "creative_controller")));
         e.getRegistry().register(BlockEntityType.Builder.of(CableBlockEntity::new, RSBlocks.CABLE.get()).build(null).setRegistryName(RS.ID, "cable"));

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -12,3 +12,9 @@ authors = "Refined Mods"
 description = '''
 An elegant solution to your hoarding problem
 '''
+[[dependencies.refinedstorage]]
+modId="forge"
+mandatory=true
+versionRange="[40.1,)"
+ordering="NONE"
+side="BOTH"


### PR DESCRIPTION
From some versions Forge has added the ability to use LootItemFunctionType in DeferredRegisters.
This fixes an issue you will have when you upgrade to 1.19, it is also what they told me on discord to use in my mods.
I have set a minimal version which I am sure this change is available, this is why I have added some lines to the toml file