### PR TITLE
Attempts to Improve on Issue #3406 (Lag with JEI recipe with multiple possible ingredients)

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/container/GridContainerMenu.java
+++ b/src/main/java/com/refinedmods/refinedstorage/container/GridContainerMenu.java
@@ -16,6 +16,7 @@ import com.refinedmods.refinedstorage.container.slot.grid.ResultCraftingGridSlot
 import com.refinedmods.refinedstorage.container.slot.legacy.LegacyBaseSlot;
 import com.refinedmods.refinedstorage.container.slot.legacy.LegacyDisabledSlot;
 import com.refinedmods.refinedstorage.container.slot.legacy.LegacyFilterSlot;
+import com.refinedmods.refinedstorage.integration.jei.GridRecipeTransferHandler;
 import com.refinedmods.refinedstorage.screen.IScreenInfoProvider;
 import com.refinedmods.refinedstorage.blockentity.BaseBlockEntity;
 import com.refinedmods.refinedstorage.blockentity.config.IType;
@@ -321,6 +322,8 @@ public class GridContainerMenu extends BaseContainerMenu implements ICraftingGri
             if (storageCache != null && storageCacheListener != null) {
                 storageCache.removeListener(storageCacheListener);
             }
+
+            GridRecipeTransferHandler.INSTANCE.cleanTrackerCache();
         }
 
         grid.removeCraftingListener(this);


### PR DESCRIPTION
*Note: this is not fully tested yet, but I don't see much of a possibility for it to break anything.*

Tested it both on a server(with the server's RS unchanged and without the fix) and singleplayer, both have significant performance boost.

As noted (somewhere) in GridRecipeTransferHandler, there's probably much better ways to fundamentally fix this.

For this is just a patch, please consider reworking the framework around Ingredient later in development, as I'm not able to provide such in a single PR or within a few hours of code reading.

However, for what it's worth, the patch is pretty effective on my machine.

*SIDENOTE: am I actually clearing the trackerCache correctly? idea is that it's supposed to be cleared when the GUI is closed, so it doesn't grow infinitely*