### PR TITLE
Fix External Storage on Storage Drawers desync on world load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed external storage cache being de-synced from the network cache.
+
 ## [v1.11.2] - 2022-12-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fixed external storage cache being de-synced from the network cache.
+- Fixed external storage using an out of date block entity for getting handler.
 
 ## [v1.11.2] - 2022-12-17
 

--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/FluidExternalStorage.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/FluidExternalStorage.java
@@ -64,6 +64,8 @@ public class FluidExternalStorage implements IExternalStorage<FluidStack> {
         IFluidHandler fluidHandler = handlerSupplier.get();
 
         if (fluidHandler != null) {
+            cache.initCache(fluidHandler);
+
             List<FluidStack> fluids = new ArrayList<>();
 
             for (int i = 0; i < fluidHandler.getTanks(); ++i) {

--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/FluidExternalStorageCache.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/FluidExternalStorageCache.java
@@ -18,23 +18,31 @@ public class FluidExternalStorageCache {
         return stored;
     }
 
+    public boolean initCache(IFluidHandler handler) {
+        if (cache != null) {
+            return false;
+        }
+
+        cache = new ArrayList<>();
+
+        int stored = 0;
+        for (int i = 0; i < handler.getTanks(); ++i) {
+            FluidStack stack = handler.getFluidInTank(i).copy();
+            cache.add(stack);
+            stored += stack.getAmount();
+        }
+        this.stored = stored;
+
+        return true;
+    }
+
     public void update(INetwork network, @Nullable IFluidHandler handler) {
         if (handler == null) {
             stored = 0;
             return;
         }
 
-        if (cache == null) {
-            cache = new ArrayList<>();
-
-            int stored = 0;
-            for (int i = 0; i < handler.getTanks(); ++i) {
-                FluidStack stack = handler.getFluidInTank(i).copy();
-                cache.add(stack);
-                stored += stack.getAmount();
-            }
-            this.stored = stored;
-
+        if (initCache(handler)) {
             return;
         }
 

--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/FluidExternalStorageProvider.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/FluidExternalStorageProvider.java
@@ -5,7 +5,9 @@ import com.refinedmods.refinedstorage.api.storage.externalstorage.IExternalStora
 import com.refinedmods.refinedstorage.api.storage.externalstorage.IExternalStorageProvider;
 import com.refinedmods.refinedstorage.blockentity.FluidInterfaceBlockEntity;
 import com.refinedmods.refinedstorage.util.LevelUtils;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.fluids.FluidStack;
 
@@ -21,11 +23,21 @@ public class FluidExternalStorageProvider implements IExternalStorageProvider<Fl
     @Override
     public IExternalStorage<FluidStack> provide(IExternalStorageContext context, BlockEntity blockEntity, Direction direction) {
         return new FluidExternalStorage(context, () -> {
-            if (!blockEntity.getLevel().isLoaded(blockEntity.getBlockPos())) {
+            Level level = blockEntity.getLevel();
+
+            if (level == null) {
                 return null;
             }
 
-            return LevelUtils.getFluidHandler(blockEntity, direction.getOpposite());
+            BlockPos blockPos = blockEntity.getBlockPos();
+
+            if (!level.isLoaded(blockPos)) {
+                return null;
+            }
+
+            BlockEntity currentBlockEntity = level.getBlockEntity(blockPos);
+
+            return LevelUtils.getFluidHandler(currentBlockEntity, direction.getOpposite());
         }, blockEntity instanceof FluidInterfaceBlockEntity);
     }
 

--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/ItemExternalStorage.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/ItemExternalStorage.java
@@ -68,6 +68,8 @@ public class ItemExternalStorage implements IExternalStorage<ItemStack> {
             return Collections.emptyList();
         }
 
+        cache.initCache(handler);
+
         List<ItemStack> stacks = new ArrayList<>();
 
         for (int i = 0; i < handler.getSlots(); ++i) {

--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/ItemExternalStorageCache.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/ItemExternalStorageCache.java
@@ -17,23 +17,31 @@ public class ItemExternalStorageCache {
         return stored;
     }
 
+    public boolean initCache(IItemHandler handler) {
+        if (cache != null) {
+            return false;
+        }
+
+        cache = new ArrayList<>();
+
+        int stored = 0;
+        for (int i = 0; i < handler.getSlots(); ++i) {
+            ItemStack stack = handler.getStackInSlot(i).copy();
+            cache.add(stack);
+            stored += stack.getCount();
+        }
+        this.stored = stored;
+
+        return true;
+    }
+
     public void update(INetwork network, @Nullable IItemHandler handler) {
         if (handler == null) {
             stored = 0;
             return;
         }
 
-        if (cache == null) {
-            cache = new ArrayList<>();
-
-            int stored = 0;
-            for (int i = 0; i < handler.getSlots(); ++i) {
-                ItemStack stack = handler.getStackInSlot(i).copy();
-                cache.add(stack);
-                stored += stack.getCount();
-            }
-            this.stored = stored;
-
+        if (initCache(handler)) {
             return;
         }
 

--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/ItemExternalStorageProvider.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/ItemExternalStorageProvider.java
@@ -6,10 +6,12 @@ import com.refinedmods.refinedstorage.api.storage.externalstorage.IExternalStora
 import com.refinedmods.refinedstorage.api.storage.externalstorage.IExternalStorageContext;
 import com.refinedmods.refinedstorage.api.storage.externalstorage.IExternalStorageProvider;
 import com.refinedmods.refinedstorage.blockentity.InterfaceBlockEntity;
-import com.refinedmods.refinedstorage.util.NetworkUtils;
 import com.refinedmods.refinedstorage.util.LevelUtils;
+import com.refinedmods.refinedstorage.util.NetworkUtils;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
 import javax.annotation.Nonnull;
@@ -30,11 +32,21 @@ public class ItemExternalStorageProvider implements IExternalStorageProvider<Ite
     @Override
     public IExternalStorage<ItemStack> provide(IExternalStorageContext context, BlockEntity blockEntity, Direction direction) {
         return new ItemExternalStorage(context, () -> {
-            if (!blockEntity.getLevel().isLoaded(blockEntity.getBlockPos())) {
+            Level level = blockEntity.getLevel();
+
+            if (level == null) {
                 return null;
             }
 
-            return LevelUtils.getItemHandler(blockEntity, direction.getOpposite());
+            BlockPos blockPos = blockEntity.getBlockPos();
+
+            if (!level.isLoaded(blockPos)) {
+                return null;
+            }
+
+            BlockEntity currentBlockEntity = level.getBlockEntity(blockPos);
+
+            return LevelUtils.getItemHandler(currentBlockEntity, direction.getOpposite());
         }, blockEntity instanceof InterfaceBlockEntity);
     }
 


### PR DESCRIPTION
This PR Fixes #2636.

There were two behaviours that contributed to the issue:

- The network's `ItemStorageCache` is [initially filled by calling `ItemExternalStorage#getStacks()`](https://github.com/refinedmods/refinedstorage/blob/9136fea35d6d41ab531cce7c1c2d8ae59503885f/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/cache/ItemStorageCache.java#L64), `ItemExternalStorageCache` fills its cache on the first update, but that update can happen after, if there was a change in that time, the deltas provided by `ItemExternalStorageCache` to the `ItemStorageCache` will show further the changes that happen in the Storage Drawers but not the ones in between.
- The `ItemExternalStorage#handlerSupplier` passed in by `ItemExternalStorageProvider` uses a captured `BlockEntity` that can become out of date with the `BlockEntity` that is actually in the `Level`.

---

Potential fixes for the first issue (External storage cache de-sync with the network cache):

1. Initialize `ItemExternalStorageCache#cache` if it needs to be when `ItemExternalStorage#getStacks()` is called.
2. Execute `ItemExternalStorage#update(INetwork)` right before `ItemStorageCache` is cleared and initially filled (when it's invalidated).

I went with the first fix but I think the second one could be good as well. Putting a breakpoint in `ItemExternalStorageCache#update(INetwork, IItemHandler)` at the return inside `if (initCache(handler))` shows that it is never reached so it might be able to be removed, but it is a sanity check in-case `ItemExternalStorageCache#update(INetwork, IItemHandler)` is ever called before `ItemExternalStorageCache#initCache(IItemHandler)`.

---

Potential fixes for the second issue (BlockEntity)

1. Re-resolve the current `BlockEntity` from the `Level` in `handlerSupplier` passed into the `ItemExternalStorageProvider#provide(IExternalStorageContext, BlockEntity, Direction)`
2. Instead of passing a `BlockEntity` into `IExternalStorageProvider#provide(...)`, it could be redefined to be a `Supplier<BlockEntity>` which gets the latest `BlockEntity`.

I went with the first fix because the second one would change the API.

---

The equivalent changes were also made to the Fluid classes but I have not tested them.

Please comment if there's better fixes for these issues or any changes to the PR.

I'm also in the Discord if it'd be easier to discuss this PR on there.

Reproducing the bug and testing the PR:

- [Before](https://www.youtube.com/watch?v=g1CxDWEBQP8)
- [After](https://www.youtube.com/watch?v=l2Xvffh4jIw)

The windows is resized smaller when loading into the world because I couldn't reproduce the bug while recording otherwise. When I'm not recording I can have the game fullscreen and still have the bug be reproducible. If I had to guess, it has to do with having too much load on the CPU and skipping ticks perhaps?

Mods:

- Minecraft 1.19.2
- Forge 43.2.0
- jei-1.19.2-forge-11.4.0.290
- StorageDrawers-1.19-11.1.2
- refinedstorage-1.11.2 / refinedstorage-1.11.3 (dev build)

Test World:

- [TestStorageDrawers-2022-12-20-1648.zip](https://github.com/refinedmods/refinedstorage/files/10267206/TestStorageDrawers-2022-12-20-1648.zip)
