### PR TITLE
Removed direct references to VanillaTypes.ITEM_STACK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fixed some craftable items not showing as craftable in JEI
+- Fixed grid crashing on exit if JEI mod is not used
 
 ## [v1.11.4] - 2022-12-20
 

--- a/src/main/java/com/refinedmods/refinedstorage/integration/jei/CoverCraftingCategoryExtension.java
+++ b/src/main/java/com/refinedmods/refinedstorage/integration/jei/CoverCraftingCategoryExtension.java
@@ -4,7 +4,6 @@ import com.refinedmods.refinedstorage.RSItems;
 import com.refinedmods.refinedstorage.apiimpl.network.node.cover.CoverManager;
 import com.refinedmods.refinedstorage.item.CoverItem;
 import com.refinedmods.refinedstorage.recipe.CoverRecipe;
-import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.builder.IRecipeSlotBuilder;
 import mezz.jei.api.gui.ingredient.ICraftingGridHelper;
@@ -55,8 +54,8 @@ public class CoverCraftingCategoryExtension implements ICraftingCategoryExtensio
         List<List<ItemStack>> inputs = new ArrayList<>(Collections.nCopies(9, new ArrayList<>()));
         inputs.set(3, nuggets);
         inputs.set(4, input);
-        List<IRecipeSlotBuilder> inputSlots = craftingGridHelper.createAndSetInputs(builder, VanillaTypes.ITEM_STACK, inputs, 3, 3);
-        IRecipeSlotBuilder outputSlot = craftingGridHelper.createAndSetOutputs(builder, VanillaTypes.ITEM_STACK, output);
+        List<IRecipeSlotBuilder> inputSlots = craftingGridHelper.createAndSetInputs(builder, inputs, 3, 3);
+        IRecipeSlotBuilder outputSlot = craftingGridHelper.createAndSetOutputs(builder, output);
 
         builder.createFocusLink(inputSlots.get(4), outputSlot);
     }

--- a/src/main/java/com/refinedmods/refinedstorage/integration/jei/GridRecipeTransferHandler.java
+++ b/src/main/java/com/refinedmods/refinedstorage/integration/jei/GridRecipeTransferHandler.java
@@ -8,7 +8,6 @@ import com.refinedmods.refinedstorage.network.grid.GridCraftingPreviewRequestMes
 import com.refinedmods.refinedstorage.network.grid.GridProcessingTransferMessage;
 import com.refinedmods.refinedstorage.network.grid.GridTransferMessage;
 import com.refinedmods.refinedstorage.screen.grid.GridScreen;
-import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.forge.ForgeTypes;
 import mezz.jei.api.gui.ingredient.IRecipeSlotView;
 import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
@@ -67,7 +66,7 @@ public class GridRecipeTransferHandler implements IRecipeTransferHandler<GridCon
 
         Ingredient.IngredientList ingredientList = new Ingredient.IngredientList();
         for (IRecipeSlotView slotView : recipeSlots.getSlotViews(RecipeIngredientRole.INPUT)) {
-            Optional<ItemStack> firstStack = slotView.getIngredients(VanillaTypes.ITEM_STACK).findAny();
+            Optional<ItemStack> firstStack = slotView.getItemStacks().findAny();
             ingredientList.add(new Ingredient(slotView, firstStack.map(ItemStack::getCount).orElse(0)));
         }
 
@@ -139,10 +138,10 @@ public class GridRecipeTransferHandler implements IRecipeTransferHandler<GridCon
         List<List<ItemStack>> inputs = recipeSlotsView.getSlotViews(RecipeIngredientRole.INPUT).stream().map(view -> {
 
             //Creating a mutable list
-            List<ItemStack> stacks = view.getIngredients(VanillaTypes.ITEM_STACK).collect(Collectors.toCollection(ArrayList::new));
+            List<ItemStack> stacks = view.getItemStacks().collect(Collectors.toCollection(ArrayList::new));
 
             //moving the displayed stack to first
-            Optional<ItemStack> displayStack = view.getDisplayedIngredient(VanillaTypes.ITEM_STACK);
+            Optional<ItemStack> displayStack = view.getDisplayedItemStack();
             displayStack.ifPresent(stack -> {
                 int index = stacks.indexOf(stack);
                 if (index > -1) {
@@ -185,11 +184,11 @@ public class GridRecipeTransferHandler implements IRecipeTransferHandler<GridCon
     }
 
     private void handleItemIngredient(List<ItemStack> list, IRecipeSlotView slotView, GridContainerMenu gridContainer, Player player) {
-        if (slotView != null && slotView.getIngredients(VanillaTypes.ITEM_STACK).findAny().isPresent()) {
-            ItemStack stack = IngredientTracker.getTracker(gridContainer).findBestMatch(gridContainer, player, slotView.getIngredients(VanillaTypes.ITEM_STACK).toList());
+        if (slotView != null && slotView.getItemStacks().findAny().isPresent()) {
+            ItemStack stack = IngredientTracker.getTracker(gridContainer).findBestMatch(gridContainer, player, slotView.getItemStacks().toList());
 
-            if (stack.isEmpty() && slotView.getDisplayedIngredient(VanillaTypes.ITEM_STACK).isPresent()) {
-                stack = slotView.getDisplayedIngredient(VanillaTypes.ITEM_STACK).get();
+            if (stack.isEmpty() && slotView.getDisplayedItemStack().isPresent()) {
+                stack = slotView.getDisplayedItemStack().get();
             }
             if (!stack.isEmpty()) {
                 list.add(stack);

--- a/src/main/java/com/refinedmods/refinedstorage/integration/jei/HollowCoverCraftingCategoryExtension.java
+++ b/src/main/java/com/refinedmods/refinedstorage/integration/jei/HollowCoverCraftingCategoryExtension.java
@@ -4,7 +4,6 @@ import com.refinedmods.refinedstorage.RSItems;
 import com.refinedmods.refinedstorage.apiimpl.network.node.cover.CoverManager;
 import com.refinedmods.refinedstorage.item.CoverItem;
 import com.refinedmods.refinedstorage.recipe.HollowCoverRecipe;
-import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.builder.IRecipeSlotBuilder;
 import mezz.jei.api.gui.ingredient.ICraftingGridHelper;
@@ -52,8 +51,8 @@ public class HollowCoverCraftingCategoryExtension implements ICraftingCategoryEx
         }
 
         stacks.set(4, input);
-        List<IRecipeSlotBuilder> inputSlots = craftingGridHelper.createAndSetInputs(builder, VanillaTypes.ITEM_STACK, stacks, 0, 0);
-        IRecipeSlotBuilder outputSlot = craftingGridHelper.createAndSetOutputs(builder, VanillaTypes.ITEM_STACK, output);
+        List<IRecipeSlotBuilder> inputSlots = craftingGridHelper.createAndSetInputs(builder, stacks, 0, 0);
+        IRecipeSlotBuilder outputSlot = craftingGridHelper.createAndSetOutputs(builder, output);
         builder.createFocusLink(inputSlots.get(4), outputSlot);
     }
 

--- a/src/main/java/com/refinedmods/refinedstorage/integration/jei/IngredientTracker.java
+++ b/src/main/java/com/refinedmods/refinedstorage/integration/jei/IngredientTracker.java
@@ -12,7 +12,6 @@ import com.refinedmods.refinedstorage.screen.grid.stack.IGridStack;
 import com.refinedmods.refinedstorage.screen.grid.stack.ItemGridStack;
 import com.refinedmods.refinedstorage.screen.grid.view.IGridView;
 import com.refinedmods.refinedstorage.util.ItemStackKey;
-import mezz.jei.api.constants.VanillaTypes;
 import net.minecraft.client.Minecraft;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.CraftingContainer;
@@ -162,7 +161,7 @@ public class IngredientTracker {
 
         //Gather available Stacks
         for (Ingredient ingredient : ingredientList.ingredients) {
-            ingredient.getSlotView().getIngredients(VanillaTypes.ITEM_STACK).takeWhile(stack -> !ingredient.isAvailable()).forEach(stack -> {
+            ingredient.getSlotView().getItemStacks().takeWhile(stack -> !ingredient.isAvailable()).forEach(stack -> {
 
                 if(ingredient.getCraftStackId() == null) {
                     ingredient.setCraftStackId(craftableItems.get(new ItemStackKey(stack)));


### PR DESCRIPTION
Fix for issue #3438 

The constant value causes the JVM to try to link JEI classes at runtime when the callers class is loaded

Luckily JEI added convenience functions to remove the need for VanillaTypes.ITEM_STACK ( https://github.com/mezz/JustEnoughItems/commit/6a332a73f789565001677f5e814533d675d35fed )