### PR TITLE
WIP: Added a new alternative autofocus

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/api/network/grid/IGrid.java
+++ b/src/main/java/com/refinedmods/refinedstorage/api/network/grid/IGrid.java
@@ -38,6 +38,7 @@ public interface IGrid {
     int SEARCH_BOX_MODE_JEI_SYNCHRONIZED_AUTOSELECTED = 3;
     int SEARCH_BOX_MODE_JEI_SYNCHRONIZED_2WAY = 4;
     int SEARCH_BOX_MODE_JEI_SYNCHRONIZED_2WAY_AUTOSELECTED = 5;
+    int SEARCH_BOX_MODE_NORMAL_AUTOSELECTED_ALT = 6;
 
     int VIEW_TYPE_NORMAL = 0;
     int VIEW_TYPE_NON_CRAFTABLES = 1;
@@ -60,13 +61,15 @@ public interface IGrid {
             mode == SEARCH_BOX_MODE_JEI_SYNCHRONIZED ||
             mode == SEARCH_BOX_MODE_JEI_SYNCHRONIZED_AUTOSELECTED ||
             mode == SEARCH_BOX_MODE_JEI_SYNCHRONIZED_2WAY ||
-            mode == SEARCH_BOX_MODE_JEI_SYNCHRONIZED_2WAY_AUTOSELECTED;
+            mode == SEARCH_BOX_MODE_JEI_SYNCHRONIZED_2WAY_AUTOSELECTED ||
+                mode == SEARCH_BOX_MODE_NORMAL_AUTOSELECTED_ALT;
     }
 
     static boolean isSearchBoxModeWithAutoselection(int mode) {
         return mode == SEARCH_BOX_MODE_NORMAL_AUTOSELECTED ||
             mode == SEARCH_BOX_MODE_JEI_SYNCHRONIZED_AUTOSELECTED ||
-            mode == SEARCH_BOX_MODE_JEI_SYNCHRONIZED_2WAY_AUTOSELECTED;
+            mode == SEARCH_BOX_MODE_JEI_SYNCHRONIZED_2WAY_AUTOSELECTED ||
+                mode == SEARCH_BOX_MODE_NORMAL_AUTOSELECTED_ALT;
     }
 
     static boolean doesSearchBoxModeUseJEI(int mode) {

--- a/src/main/java/com/refinedmods/refinedstorage/screen/widget/SearchWidget.java
+++ b/src/main/java/com/refinedmods/refinedstorage/screen/widget/SearchWidget.java
@@ -157,7 +157,8 @@ public class SearchWidget extends EditBox {
     public void setMode(int mode) {
         this.mode = mode;
 
-        this.setCanLoseFocus(!IGrid.isSearchBoxModeWithAutoselection(mode));
+
+        this.setCanLoseFocus(!IGrid.isSearchBoxModeWithAutoselection(mode) || this.mode == IGrid.SEARCH_BOX_MODE_NORMAL_AUTOSELECTED_ALT);
         this.setFocused(IGrid.isSearchBoxModeWithAutoselection(mode));
 
         if (canSyncFromJEINow()) {

--- a/src/main/java/com/refinedmods/refinedstorage/screen/widget/sidebutton/SearchBoxModeSideButton.java
+++ b/src/main/java/com/refinedmods/refinedstorage/screen/widget/sidebutton/SearchBoxModeSideButton.java
@@ -14,6 +14,7 @@ public abstract class SearchBoxModeSideButton extends SideButton {
     private static final List<Integer> MODE_ROTATION = Arrays.asList(
         IGrid.SEARCH_BOX_MODE_NORMAL,
         IGrid.SEARCH_BOX_MODE_NORMAL_AUTOSELECTED,
+        IGrid.SEARCH_BOX_MODE_NORMAL_AUTOSELECTED_ALT,
         IGrid.SEARCH_BOX_MODE_JEI_SYNCHRONIZED,
         IGrid.SEARCH_BOX_MODE_JEI_SYNCHRONIZED_AUTOSELECTED,
         IGrid.SEARCH_BOX_MODE_JEI_SYNCHRONIZED_2WAY,

--- a/src/main/resources/assets/refinedstorage/lang/en_us.json
+++ b/src/main/resources/assets/refinedstorage/lang/en_us.json
@@ -178,6 +178,7 @@
   "sidebutton.refinedstorage.grid.search_box_mode.3": "JEI synchronized (autoselected)",
   "sidebutton.refinedstorage.grid.search_box_mode.4": "JEI synchronized (two-way)",
   "sidebutton.refinedstorage.grid.search_box_mode.5": "JEI synchronized (two-way autoselected)",
+  "sidebutton.refinedstorage.grid.search_box_mode.6": "Normal (autoselected alternative)",
   "sidebutton.refinedstorage.grid.size": "Size",
   "sidebutton.refinedstorage.grid.size.0": "Stretch",
   "sidebutton.refinedstorage.grid.size.1": "Small",


### PR DESCRIPTION
In relation to issue #3441, the normal autoselect mode was unable to lose focus, thus preventing JEI usage when the normal autoselected mode was being used.

This PR implements a new search box mode, "Normal (autoselected alternative)", which allows the search box to be automatically focused on opening the grid, but it allows it to lose focus, thus enabling JEI usage.

Currently there is an issue with this implementation (The reason why this PR is WIP) that I am not quite sure how to fix because I am not familiar with the source code:

Using the "Normal (autoselected alternative)" mode, follow the steps:

- Search box starts autoselected, search for an item
- Click on the JEI search bar (This step does NOT defocus the search box, even though it should)
- Click anywhere outside the grid GUI (This step defocuses the search box)
- Click on the grid search box to re-focus
- Click on the JEI search bar (Now, the grid search box properly gets defocused)