### PR TITLE
fix racecondition with Itemstack.EMPTY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fixed some craftable items not showing as craftable in JEI
 - Fixed grid crashing on exit if JEI mod is not used
+- Fixed rare multithreading crash
 
 ## [v1.11.4] - 2022-12-20
 

--- a/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/ItemExternalStorageCache.java
+++ b/src/main/java/com/refinedmods/refinedstorage/apiimpl/storage/externalstorage/ItemExternalStorageCache.java
@@ -62,6 +62,10 @@ public class ItemExternalStorageCache {
 
             ItemStack cached = cache.get(i);
 
+            //ItemStack.EMPTY can be accidentally modified by other mods on any thread. This makes sure we ignore that.
+            if (actual == ItemStack.EMPTY && actual == cached)
+                continue;
+
             if (!cached.isEmpty() && actual.isEmpty()) { // REMOVED
                 network.getItemStorageCache().remove(cached, cached.getCount(), true);
 


### PR DESCRIPTION
Fixes https://github.com/refinedmods/refinedstorage/issues/3454

test world ran for 2 hours without issue (reproduced twice before in < 10 min)

also provides a small performance boost for empty containers

