### PR TITLE
Fix #3441 by correctly synchronizing focus on screen init

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/screen/CrafterManagerScreen.java
+++ b/src/main/java/com/refinedmods/refinedstorage/screen/CrafterManagerScreen.java
@@ -70,6 +70,9 @@ public class CrafterManagerScreen extends BaseScreen<CrafterManagerContainerMenu
         }
 
         addRenderableWidget(searchField);
+        if (searchField.isFocused()) {
+            setFocused(searchField);
+        }
     }
 
     @Override

--- a/src/main/java/com/refinedmods/refinedstorage/screen/grid/GridScreen.java
+++ b/src/main/java/com/refinedmods/refinedstorage/screen/grid/GridScreen.java
@@ -146,6 +146,9 @@ public class GridScreen extends BaseScreen<GridContainerMenu> implements IScreen
         }
 
         addRenderableWidget(searchField);
+        if (searchField.isFocused()) {
+            setFocused(searchField);
+        }
 
         if (grid.getViewType() != -1) {
             addSideButton(new GridViewTypeSideButton(this, grid));


### PR DESCRIPTION
This fixes [#3441](https://github.com/refinedmods/refinedstorage/issues/3441).
Specifically, it fixes the fact that the JEI search box cannot be selected after opening the UI in normal autoselect mode. It does not implement any of the alternate behaviors proposed in the issue and as far as I know does not change any behavior outside of allowing the selection of the JEI box in autoselect mode.

Note: It is actually possible to select the JEI box without this fix, but doing so requires you to first click on the already selected grid search box and then on the JEI box.