### PR TITLE
Improve performance of insert and extract for Item Storage Disks

### DIFF
--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/storage/disk/StorageDiskFactoryItem.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/storage/disk/StorageDiskFactoryItem.java
@@ -25,6 +25,8 @@ public class StorageDiskFactoryItem implements IStorageDiskFactory<ItemStack> {
             }
         }
 
+        disk.recalculateStored();
+
         return disk;
     }
 

--- a/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/storage/disk/StorageDiskItem.java
+++ b/src/main/java/com/raoulvdberge/refinedstorage/apiimpl/storage/disk/StorageDiskItem.java
@@ -30,6 +30,8 @@ public class StorageDiskItem implements IStorageDisk<ItemStack> {
     private int capacity;
     private Multimap<Item, ItemStack> stacks = ArrayListMultimap.create();
 
+    private int storedAmount = 0;
+
     @Nullable
     private IStorageDiskListener listener;
     private IStorageDiskContainerContext context;
@@ -85,6 +87,8 @@ public class StorageDiskItem implements IStorageDisk<ItemStack> {
                     if (action == Action.PERFORM) {
                         otherStack.grow(remainingSpace);
 
+                        this.storedAmount += remainingSpace;
+
                         onChanged();
                     }
 
@@ -92,6 +96,8 @@ public class StorageDiskItem implements IStorageDisk<ItemStack> {
                 } else {
                     if (action == Action.PERFORM) {
                         otherStack.grow(size);
+
+                        this.storedAmount += size;
 
                         onChanged();
                     }
@@ -111,6 +117,8 @@ public class StorageDiskItem implements IStorageDisk<ItemStack> {
             if (action == Action.PERFORM) {
                 stacks.put(stack.getItem(), ItemHandlerHelper.copyStackWithSize(stack, remainingSpace));
 
+                this.storedAmount += remainingSpace;
+
                 onChanged();
             }
 
@@ -118,6 +126,8 @@ public class StorageDiskItem implements IStorageDisk<ItemStack> {
         } else {
             if (action == Action.PERFORM) {
                 stacks.put(stack.getItem(), ItemHandlerHelper.copyStackWithSize(stack, size));
+
+                this.storedAmount += size;
 
                 onChanged();
             }
@@ -142,6 +152,8 @@ public class StorageDiskItem implements IStorageDisk<ItemStack> {
                         otherStack.shrink(size);
                     }
 
+                    this.storedAmount -= size;
+
                     onChanged();
                 }
 
@@ -154,7 +166,18 @@ public class StorageDiskItem implements IStorageDisk<ItemStack> {
 
     @Override
     public int getStored() {
-        return stacks.values().stream().mapToInt(ItemStack::getCount).sum();
+        return this.storedAmount;
+    }
+
+    void recalculateStored() {
+        this.storedAmount = calculateStored();
+    }
+
+    private int calculateStored() {
+        return stacks.values()
+                .stream()
+                .mapToInt(ItemStack::getCount)
+                .sum();
     }
 
     @Override


### PR DESCRIPTION
Hi, we've had performance problems in combination with Reborn Storage due to the extremely large item disks. After profiling I've found that a significant amount of time (roughly 70 ms / tick) was spent on simply iterating through the items to count the stored amount. I've added a field to track it on insertion/extraction instead which improved performance massively in our case (lots of items, ~7500 insertions/extractions per second).
We've been running this modified version on our server for a few days now and had no issues.
I don't know if you want to merge it since it's for an old version, but I thought I'll just open the PR anyways.