### PR TITLE
Fix stacks having superfluous NBT and fluids in the pattern grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Fixed
+- Fixed items in disks deserializing with an empty NBT tag.
 - Fixed placing fluids in the pattern grid disconnecting the client.
 
 ## [1.13.0-beta.2] - 2024-02-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- Fixed placing fluids in the pattern grid disconnecting the client.
+
 ## [1.13.0-beta.2] - 2024-02-16
 
 ### Fixed

--- a/src/main/java/com/refinedmods/refinedstorage/network/NetworkHandler.java
+++ b/src/main/java/com/refinedmods/refinedstorage/network/NetworkHandler.java
@@ -55,7 +55,7 @@ public class NetworkHandler {
         registrar.play(
             FluidFilterSlotUpdateMessage.ID,
             FluidFilterSlotUpdateMessage::decode,
-            handler -> handler.server(FluidFilterSlotUpdateMessage::handle)
+            handler -> handler.client(FluidFilterSlotUpdateMessage::handle)
         );
         registrar.play(
             BlockEntitySynchronizationParameterMessage.ID,

--- a/src/main/java/com/refinedmods/refinedstorage/util/StackUtils.java
+++ b/src/main/java/com/refinedmods/refinedstorage/util/StackUtils.java
@@ -338,7 +338,7 @@ public final class StackUtils {
         return AttachmentInternals.reconstructItemStack(
             BuiltInRegistries.ITEM.get(new ResourceLocation(tag.getString(NBT_ITEM_ID))),
             tag.getInt(NBT_ITEM_QUANTITY),
-            tag.getCompound(NBT_ITEM_NBT)
+            tag.contains(NBT_ITEM_NBT) ? tag.getCompound(NBT_ITEM_NBT) : null
         );
     }
 }


### PR DESCRIPTION
The `FluidFilterSlotUpdateMessage` needs to be only handled on the client.
`CompoundTag#getCompound` always returns a tag, never null, causing deserialized items to have superfluous empty NBT.