### PR TITLE
Add direction null check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -   Added Hungarian translation.
 
+### Fixed
+
+-   Fixed an error that occurred when targeting the crafter with Jade installed
+
 ## [1.13.0-beta.3] - 2024-03-05
 
 ### Fixed

--- a/src/main/java/com/refinedmods/refinedstorage/blockentity/CrafterBlockEntity.java
+++ b/src/main/java/com/refinedmods/refinedstorage/blockentity/CrafterBlockEntity.java
@@ -8,6 +8,7 @@ import com.refinedmods.refinedstorage.blockentity.data.BlockEntitySynchronizatio
 import com.refinedmods.refinedstorage.screen.CrafterBlockEntitySynchronizationClientListener;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -44,8 +45,8 @@ public class CrafterBlockEntity extends NetworkNodeBlockEntity<CrafterNetworkNod
         return new CrafterNetworkNode(level, pos);
     }
 
-    public IItemHandler getPatterns(Direction direction) {
-        if (!direction.equals(this.getNode().getDirection())) {
+    public IItemHandler getPatterns(@Nullable Direction direction) {
+        if (direction != null && !direction.equals(this.getNode().getDirection())) {
             return getNode().getPatternInventory();
         }
         return null;


### PR DESCRIPTION
Fixed an error that occurred when targeting the crafter with Jade installed

```
Caused by: java.lang.NullPointerException: Cannot invoke "net.minecraft.core.Direction.equals(Object)" because "direction" is null
	at com.refinedmods.refinedstorage.blockentity.CrafterBlockEntity.getPatterns(CrafterBlockEntity.java:48) ~[refinedstorage-1.13.0-beta.3.jar%23189!/:?] {re:classloading}
	at net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent.lambda$registerBlockEntity$1(RegisterCapabilitiesEvent.java:64) ~[neoforge-20.4.192.jar%23184%23187!/:?] {re:classloading}
	at net.neoforged.neoforge.capabilities.BlockCapability.getCapability(BlockCapability.java:158) ~[neoforge-20.4.192.jar%23184%23187!/:?] {re:classloading}
	at net.neoforged.neoforge.common.extensions.ILevelExtension.getCapability(ILevelExtension.java:74) ~[neoforge-20.4.192.jar%23184%23187!/:?] {re:classloading}
	at snownee.jade.util.CommonProxy.findItemHandler(CommonProxy.java:220) ~[jade-324717-5109393.jar%23190!/:13.3.1] {re:classloading}
	at snownee.jade.util.CommonProxy.createItemCollector(CommonProxy.java:170) ~[jade-324717-5109393.jar%23190!/:13.3.1] {re:classloading}
	at snownee.jade.addon.universal.ItemStorageProvider.lambda$getGroups$4(ItemStorageProvider.java:244) ~[jade-324717-5109393.jar%23190!/:13.3.1] {re:classloading}
```