### PR TITLE
Docs/no issue/add remove controller on receiver side

### DIFF
--- a/docs/pages/wireless-networking/networks-over-long-distances.adoc
+++ b/docs/pages/wireless-networking/networks-over-long-distances.adoc
@@ -26,7 +26,7 @@ I'll be telling what you need this for in a second, bear with me.
 
 After crafting a xref:network-card.adoc[], craft a xref:network-receiver.adoc[] and place it in the area far away from your base. 
 
-If the receiver was added to an existing network, remove the controller from that network, the receiver will act as a controller.
+If the xref:network-receiver.adoc[] was added to an existing network, remove the xref:../networking/controller.adoc[] from that network, the receiver will act as a controller.
 
 Take the xref:network-card.adoc[] and right click it on the xref:network-receiver.adoc[].
 

--- a/docs/pages/wireless-networking/networks-over-long-distances.adoc
+++ b/docs/pages/wireless-networking/networks-over-long-distances.adoc
@@ -24,7 +24,9 @@ Simply craft a xref:network-transmitter.adoc[] and connect it to your Refined St
 Next up, craft a xref:network-card.adoc[].
 I'll be telling what you need this for in a second, bear with me.
 
-After crafting a xref:network-card.adoc[], craft a xref:network-receiver.adoc[] and place it in the area far away from your base.
+After crafting a xref:network-card.adoc[], craft a xref:network-receiver.adoc[] and place it in the area far away from your base. 
+
+If the receiver was added to an existing network, remove the controller from that network, the receiver will act as a controller.
 
 Take the xref:network-card.adoc[] and right click it on the xref:network-receiver.adoc[].
 


### PR DESCRIPTION
Added a line on [the page : Networks over long distances](https://refinedmods.com/refined-storage/wireless-networking/networks-over-long-distances.html) to tell the users that they should remove the controller from the receiver side if there is one