### PR TITLE
Fix poseStack translation leak in JEI RecipeTransferCraftingGridError

### DIFF
--- a/src/main/java/com/refinedmods/refinedstorage/integration/jei/RecipeTransferCraftingGridError.java
+++ b/src/main/java/com/refinedmods/refinedstorage/integration/jei/RecipeTransferCraftingGridError.java
@@ -1,5 +1,6 @@
 package com.refinedmods.refinedstorage.integration.jei;
 
+import com.mojang.blaze3d.vertex.PoseStack;
 import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
 import mezz.jei.api.recipe.transfer.IRecipeTransferError;
 import net.minecraft.ChatFormatting;
@@ -39,9 +40,12 @@ public class RecipeTransferCraftingGridError implements IRecipeTransferError {
 
     @Override
     public void showError(GuiGraphics graphics, int mouseX, int mouseY, IRecipeSlotsView recipeSlotsView, int recipeX, int recipeY) {
-        graphics.pose().translate(recipeX, recipeY, 0);
+        PoseStack poseStack = graphics.pose();
+        poseStack.pushPose();
+        poseStack.translate(recipeX, recipeY, 0);
         List<Component> message = drawIngredientHighlights(graphics, recipeX, recipeY);
         graphics.renderComponentTooltip(Minecraft.getInstance().font, message, mouseX, mouseY);
+        poseStack.popPose();
     }
 
     protected List<Component> drawIngredientHighlights(GuiGraphics graphics, int recipeX, int recipeY) {


### PR DESCRIPTION
Fix for
* https://github.com/mezz/JustEnoughItems/issues/3630

RS has a `poseStack.translate` with pushing and popping the stack, resulting in a leaked translation.

Before fix, hovering over the crafting button would shift GUI elements around:
![Bug JEI - Refined](https://github.com/user-attachments/assets/18164f9e-c035-4ceb-b91d-79f7982fb0b1)

After fix:
![Screenshot 2024-07-26 at 8 53 45 AM](https://github.com/user-attachments/assets/5f070c48-c9b5-4bce-9b60-f65d144d665a)

I added mitigation for this in JEI as well but I think this is the "correct" place for the fix to be.